### PR TITLE
Fix: Coldstart delay

### DIFF
--- a/app/http.php
+++ b/app/http.php
@@ -624,16 +624,16 @@ App::post('/v1/runtimes/:runtimeId/execution')
             }
 
             // Ensure runtime started
-            for ($i = 0; $i < 5; $i++) {
+            for ($i = 0; $i < 50; $i++) {
                 if ($activeRuntimes->get($activeRuntimeId)['status'] !== 'pending') {
                     break;
                 }
 
-                if ($i === 4) {
+                if ($i === 49) {
                     throw new Exception('Runtime failed to launch in allocated time.', 500);
                 }
 
-                \sleep(1);
+                \sleep(0.1);
             }
 
             // Ensure we have secret
@@ -696,7 +696,7 @@ App::post('/v1/runtimes/:runtimeId/execution')
             };
 
             // Execute function
-            for ($i = 0; $i < 5; $i++) {
+            for ($i = 0; $i < 50; $i++) {
                 [ 'errNo' => $errNo, 'error' => $error, 'statusCode' => $statusCode, 'executorResponse' => $executorResponse ] = \call_user_func($sendExecuteRequest);
 
                 // No error
@@ -708,11 +708,11 @@ App::post('/v1/runtimes/:runtimeId/execution')
                     throw new Exception('An internal curl error has occurred within the executor! Error Msg: ' . $error, 500);
                 }
 
-                if ($i === 4) {
+                if ($i === 49) {
                     throw new Exception('An internal curl error has occurred within the executor! Error Msg: ' . $error, 500);
                 }
 
-                \sleep(1);
+                \sleep(0.1);
             }
 
             // Extract response


### PR DESCRIPTION
There is a lot of delay because of `sleep` we do in multiple places. This PR is supposed to find better ways of doing these repetitive checks in order to speed up the process.