### PR TITLE
fix: delete active runtimes from the swoole table on failure

### DIFF
--- a/app/http.php
+++ b/app/http.php
@@ -921,11 +921,11 @@ run(function () use ($register) {
                         $connection = $orchestrationPool->pop();
                         $orchestration = $connection->getResource();
                         $orchestration->remove($runtime['name'], true);
-                        $activeRuntimes->del($activeRuntimeId);
                         Console::success("Successfully removed {$runtime['name']}");
                     } catch (\Throwable $th) {
                         Console::error('Inactive Runtime deletion failed: ' . $th->getMessage());
                     } finally {
+                        $activeRuntimes->del($activeRuntimeId);
                         isset($connection) && $connection->reclaim();
                     }
                 });


### PR DESCRIPTION
It was observed that if there is an error during the maintenance task execution on the executor it would continue to keep it in the swoole table and try to delete that container indefinitely as seen from the logs here.

![Screenshot 2022-11-10 at 7 08 12 PM](https://user-images.githubusercontent.com/20852629/201106269-3c2b67ab-6c51-4b0b-b66e-119d50069cb1.png)

