### PR TITLE
Fix: Build race condition

### DIFF
--- a/app/http.php
+++ b/app/http.php
@@ -295,17 +295,15 @@ App::post('/v1/runtimes')
 
         $secret = \bin2hex(\random_bytes(16));
 
-        if (!$remove) {
-            $activeRuntimes->set($activeRuntimeId, [
-                'id' => $containerId,
-                'name' => $activeRuntimeId,
-                'hostname' => $runtimeHostname,
-                'created' => (int) $startTimeUnix,
-                'updated' => \time(),
-                'status' => 'pending',
-                'key' => $secret,
-            ]);
-        }
+        $activeRuntimes->set($activeRuntimeId, [
+            'id' => $containerId,
+            'name' => $activeRuntimeId,
+            'hostname' => $runtimeHostname,
+            'created' => (int) $startTimeUnix,
+            'updated' => \time(),
+            'status' => 'pending',
+            'key' => $secret,
+        ]);
 
         /**
          * Temporary file paths in the executor
@@ -428,28 +426,26 @@ App::post('/v1/runtimes')
                 'duration' => $duration,
             ]);
 
-            if (!$remove) {
-                $activeRuntimes->set($activeRuntimeId, [
-                    'id' => $containerId,
-                    'name' => $activeRuntimeId,
-                    'hostname' => $runtimeHostname,
-                    'created' => (int) $startTimeUnix,
-                    'updated' => \time(),
-                    'status' => 'Up ' . \round($duration, 2) . 's',
-                    'key' => $secret,
-                ]);
-            }
+            $activeRuntimes->set($activeRuntimeId, [
+                'id' => $containerId,
+                'name' => $activeRuntimeId,
+                'hostname' => $runtimeHostname,
+                'created' => (int) $startTimeUnix,
+                'updated' => \time(),
+                'status' => 'Up ' . \round($duration, 2) . 's',
+                'key' => $secret,
+            ]);
         } catch (Throwable $th) {
             $localDevice->delete($tmpSource);
             $localDevice->delete($tmpBuild);
-
-            $activeRuntimes->del($activeRuntimeId);
 
             // Silently try to kill container
             try {
                 $orchestration->remove($containerId, true);
             } catch(Throwable $th) {
             }
+
+            $activeRuntimes->del($activeRuntimeId);
 
             throw new Exception($th->getMessage() . $stdout, 500);
         }
@@ -466,6 +462,8 @@ App::post('/v1/runtimes')
                 $orchestration->remove($containerId, true);
             } catch (Throwable $th) {
             }
+
+            $activeRuntimes->del($activeRuntimeId);
         }
 
         $response

--- a/app/http.php
+++ b/app/http.php
@@ -455,8 +455,6 @@ App::post('/v1/runtimes')
 
         // Container cleanup
         if ($remove) {
-            $activeRuntimes->del($activeRuntimeId);
-
             // Silently try to kill container
             try {
                 $orchestration->remove($containerId, true);


### PR DESCRIPTION
There are 2 possible race conditions that would result in Docker CLI error - duplicate container name.

1. Retrying failed build too quickly
2. Starting 2 builds of same name at the same time

This PR solves both.