### PR TITLE
Fix: stderr response

### DIFF
--- a/app/http.php
+++ b/app/http.php
@@ -735,7 +735,7 @@ App::post('/v1/runtimes/:runtimeId/execution')
             $stderr = $executorResponse['stderr'] ?? '';
             $stdout = $executorResponse['stdout'] ?? '';
 
-            if($statusCode >= 200 && $statusCode < 300) {
+            if ($statusCode >= 200 && $statusCode < 300) {
                 $res = $executorResponse['response'] ?? '';
                 if (is_array($res)) {
                     $res = json_encode($res, JSON_UNESCAPED_UNICODE | JSON_FORCE_OBJECT);

--- a/app/http.php
+++ b/app/http.php
@@ -728,16 +728,19 @@ App::post('/v1/runtimes/:runtimeId/execution')
             }
 
             // Extract response
-            $executorResponse = json_decode($executorResponse ?? '{}', true);
+            $executorResponse = json_decode($executorResponse ?? '{}', false);
 
             $execution = [];
             $res = '';
-            $stderr = $executorResponse['stderr'] ?? '';
-            $stdout = $executorResponse['stdout'] ?? '';
+            $stderr = $executorResponse->stderr ?? '';
+            $stdout = $executorResponse->stdout ?? '';
 
             if ($statusCode >= 200 && $statusCode < 300) {
-                $res = $executorResponse['response'] ?? '';
+                $res = $executorResponse->response ?? '';
                 if (is_array($res)) {
+                    $res = json_encode($res, JSON_UNESCAPED_UNICODE);
+                }
+                if (is_object($res)) {
                     $res = json_encode($res, JSON_UNESCAPED_UNICODE | JSON_FORCE_OBJECT);
                 }
             }

--- a/app/http.php
+++ b/app/http.php
@@ -735,12 +735,11 @@ App::post('/v1/runtimes/:runtimeId/execution')
             $stderr = $executorResponse->stderr ?? '';
             $stdout = $executorResponse->stdout ?? '';
 
-            if ($statusCode >= 200 && $statusCode < 300) {
+            if ($statusCode >= 200 && $statusCode < 500) {
                 $res = $executorResponse->response ?? '';
                 if (is_array($res)) {
                     $res = json_encode($res, JSON_UNESCAPED_UNICODE);
-                }
-                if (is_object($res)) {
+                } elseif (is_object($res)) {
                     $res = json_encode($res, JSON_UNESCAPED_UNICODE | JSON_FORCE_OBJECT);
                 }
             }

--- a/app/http.php
+++ b/app/http.php
@@ -728,29 +728,18 @@ App::post('/v1/runtimes/:runtimeId/execution')
             }
 
             // Extract response
-            $execution = [];
-            $stdout = '';
-            $stderr = '';
-            $res = '';
-
             $executorResponse = json_decode($executorResponse ?? '{}', true);
 
-            switch (true) {
-                case $statusCode >= 500:
-                    $stderr = $executorResponse['stderr'] ?? '';
-                    $stdout = $executorResponse['stdout'] ?? '';
-                    break;
-                case $statusCode >= 100:
-                    $stdout = $executorResponse['stdout'] ?? '';
-                    $res = $executorResponse['response'] ?? '';
-                    if (is_array($res)) {
-                        $res = json_encode($res, JSON_UNESCAPED_UNICODE);
-                    }
-                    break;
-                default:
-                    $stderr = $executorResponse['stderr'] ?? '';
-                    $stdout = $executorResponse['stdout'] ?? '';
-                    break;
+            $execution = [];
+            $res = '';
+            $stderr = $executorResponse['stderr'] ?? '';
+            $stdout = $executorResponse['stdout'] ?? '';
+
+            if($statusCode >= 200 && $statusCode < 300) {
+                $res = $executorResponse['response'] ?? '';
+                if (is_array($res)) {
+                    $res = json_encode($res, JSON_UNESCAPED_UNICODE | JSON_FORCE_OBJECT);
+                }
             }
 
 

--- a/tests/ExecutorTest.php
+++ b/tests/ExecutorTest.php
@@ -201,6 +201,17 @@ final class ExecutorTest extends TestCase
             [
                 'image' => 'openruntimes/node:v2-18.0',
                 'entrypoint' => 'index.js',
+                'folder' => 'node-empty-array',
+                'assertions' => function ($response) {
+                    $this->assertEquals('completed', $response['body']['status']);
+                    $this->assertEquals('[]', $response['body']['response']);
+                    $this->assertEmpty($response['body']['stdout']);
+                    $this->assertEmpty($response['body']['stderr']);
+                }
+            ],
+            [
+                'image' => 'openruntimes/node:v2-18.0',
+                'entrypoint' => 'index.js',
                 'folder' => 'node-stderr',
                 'assertions' => function ($response) {
                     $this->assertEquals('completed', $response['body']['status']);

--- a/tests/ExecutorTest.php
+++ b/tests/ExecutorTest.php
@@ -214,8 +214,8 @@ final class ExecutorTest extends TestCase
                 'entrypoint' => 'index.php',
                 'folder' => 'php-timeout',
                 'assertions' => function ($response) {
-                    \var_dump($response);
-                    $this->assertEquals('failed', $response['body']['status']);
+                    $this->assertEquals(500, $response['headers']['status-code']);
+                    $this->assertEquals(500, $response['body']['code']);
                     $this->assertStringContainsString('Operation timed out', $response['body']['message']);
                 }
             ]
@@ -270,7 +270,7 @@ final class ExecutorTest extends TestCase
         call_user_func($assertions, $response);
 
         /** Delete runtime */
-        $response = $this->client->call(Client::METHOD_DELETE, "/runtimes/{$folder}", [], []);
+        $response = $this->client->call(Client::METHOD_DELETE, "/runtimes/scenario-execute-{$folder}", [], []);
         $this->assertEquals(200, $response['headers']['status-code']);
     }
 

--- a/tests/ExecutorTest.php
+++ b/tests/ExecutorTest.php
@@ -195,7 +195,7 @@ final class ExecutorTest extends TestCase
                     $this->assertEquals('completed', $response['body']['status']);
                     $this->assertEquals('{}', $response['body']['response']);
                     $this->assertEmpty($response['body']['stdout']);
-                    $this->assertEmpty('Error log', $response['body']['stderr']);
+                    $this->assertEmpty($response['body']['stderr']);
                 }
             ],
             [
@@ -241,7 +241,7 @@ final class ExecutorTest extends TestCase
 
         /** Build runtime */
         $params = [
-            'runtimeId' => 'test-build',
+            'runtimeId' => "scenario-build-{$folder}",
             'source' => "/storage/functions/{$folder}/code.tar.gz",
             'destination' => '/storage/builds/test',
             'entrypoint' => $entrypoint,
@@ -261,7 +261,7 @@ final class ExecutorTest extends TestCase
         $path = $response['body']['path'];
 
         /** Execute function */
-        $response = $this->client->call(Client::METHOD_POST, "/runtimes/{$folder}/execution", [], [
+        $response = $this->client->call(Client::METHOD_POST, "/runtimes/scenario-execute-{$folder}/execution", [], [
             'source' => $path,
             'entrypoint' => $entrypoint,
             'image' => $image,

--- a/tests/ExecutorTest.php
+++ b/tests/ExecutorTest.php
@@ -228,7 +228,7 @@ final class ExecutorTest extends TestCase
      * @param string $folder
      * @param callable $assertions
      *
-     * @dataProvider provideCustomRuntimes
+     * @dataProvider provideScenarios
      */
     public function testScenarios(string $image, string $entrypoint, string $folder, callable $assertions): void
     {

--- a/tests/ExecutorTest.php
+++ b/tests/ExecutorTest.php
@@ -191,7 +191,7 @@ final class ExecutorTest extends TestCase
                 'image' => 'openruntimes/node:v2-18.0',
                 'entrypoint' => 'index.js',
                 'folder' => 'node-empty-object',
-                'assertions' => function($response) {
+                'assertions' => function ($response) {
                     $this->assertEquals('completed', $response['body']['status']);
                     $this->assertEquals('{}', $response['body']['response']);
                     $this->assertEmpty($response['body']['stdout']);
@@ -202,7 +202,7 @@ final class ExecutorTest extends TestCase
                 'image' => 'openruntimes/node:v2-18.0',
                 'entrypoint' => 'index.js',
                 'folder' => 'node-stderr',
-                'assertions' => function($response) {
+                'assertions' => function ($response) {
                     $this->assertEquals('completed', $response['body']['status']);
                     $this->assertEquals('{"ok":true}', $response['body']['response']);
                     $this->assertEmpty($response['body']['stdout']);
@@ -213,7 +213,7 @@ final class ExecutorTest extends TestCase
                 'image' => 'openruntimes/php:v2-8.1',
                 'entrypoint' => 'index.php',
                 'folder' => 'php-timeout',
-                'assertions' => function($response) {
+                'assertions' => function ($response) {
                     \var_dump($response);
                     $this->assertEquals('failed', $response['body']['status']);
                     $this->assertStringContainsString('Operation timed out', $response['body']['message']);
@@ -223,7 +223,10 @@ final class ExecutorTest extends TestCase
     }
 
     /**
-     * @param array<mixed> $data
+     * @param string $image
+     * @param string $entrypoint
+     * @param string $folder
+     * @param callable $assertions
      *
      * @dataProvider provideCustomRuntimes
      */
@@ -255,11 +258,11 @@ final class ExecutorTest extends TestCase
         $this->assertEquals(201, $response['headers']['status-code']);
         $this->assertEquals('ready', $response['body']['status']);
 
-        $outputPath = $response['body']['outputPath'];
+        $path = $response['body']['path'];
 
         /** Execute function */
         $response = $this->client->call(Client::METHOD_POST, "/runtimes/{$folder}/execution", [], [
-            'source' => $outputPath,
+            'source' => $path,
             'entrypoint' => $entrypoint,
             'image' => $image,
         ]);
@@ -291,7 +294,9 @@ final class ExecutorTest extends TestCase
     }
 
     /**
-     * @param array<mixed> $data
+     * @param string $folder
+     * @param string $image
+     * @param string $entrypoint
      *
      * @dataProvider provideCustomRuntimes
      */
@@ -323,15 +328,15 @@ final class ExecutorTest extends TestCase
         $response = $this->client->call(Client::METHOD_POST, '/runtimes', [], $params);
         $this->assertEquals(201, $response['headers']['status-code']);
         $this->assertEquals('ready', $response['body']['status']);
-        $this->assertIsString($response['body']['outputPath']);
+        $this->assertIsString($response['body']['path']);
 
-        $outputPath = $response['body']['outputPath'];
+        $path = $response['body']['path'];
 
         // Execute function
         $response = $this->client->call(Client::METHOD_POST, "/runtimes/custom-execute-{$folder}/execution", [
             'content-type' => 'application/json',
         ], [
-            'source' => $outputPath,
+            'source' => $path,
             'entrypoint' => $entrypoint,
             'image' => $image,
             'timeout' => 60,

--- a/tests/resources/functions/node-empty-array/index.js
+++ b/tests/resources/functions/node-empty-array/index.js
@@ -1,0 +1,3 @@
+module.exports = async (req, res) => {
+    res.json([]);
+}

--- a/tests/resources/functions/node-empty-object/index.js
+++ b/tests/resources/functions/node-empty-object/index.js
@@ -1,0 +1,3 @@
+module.exports = async (req, res) => {
+    res.json({});
+}

--- a/tests/resources/functions/node-stderr/index.js
+++ b/tests/resources/functions/node-stderr/index.js
@@ -1,0 +1,4 @@
+module.exports = async (req, res) => {
+    console.error("Error log");
+    res.json({ ok:true });
+}


### PR DESCRIPTION
With successful execution, stderr was ignored. Now both stdout and stderr are ALWAYS present, as intended.

+ I noticed small bug when empty object is translated to empty array. Fixed that.

I also improved maintainability of tests a little to prevent code duplication.
With that I added tests for some more edge cases: stderr, json object response.