### PR TITLE
Fix: Remote storage

### DIFF
--- a/app/http.php
+++ b/app/http.php
@@ -429,7 +429,7 @@ App::post('/v1/runtimes')
              * Copy code files from source to a temporary location on the executor
              */
             if (!empty($source)) {
-                if (!$localDevice->transfer($source, $tmpSource, $sourceDevice)) {
+                if (!$sourceDevice->transfer($source, $tmpSource, $localDevice)) {
                     throw new Exception('Failed to copy source code to temporary directory', 500);
                 };
             }


### PR DESCRIPTION
Quick fix of a bug when using different device than local.

Nessessary before using latest version of Executor with Appwrite 1.4, otherwise all builds with cloud storage provider fails.


- [x] Manual QA