### PR TITLE
Fix: coroutines memory limit

### DIFF
--- a/app/http.php
+++ b/app/http.php
@@ -42,6 +42,9 @@ use Utopia\Registry\Registry;
 use function Swoole\Coroutine\batch;
 use function Swoole\Coroutine\run;
 
+// Unlimited memory limit to handle as many coroutines/requests as possible
+ini_set('memory_limit', '-1');
+
 Runtime::enableCoroutine(true, SWOOLE_HOOK_ALL);
 
 Http::setMode((string) Http::getEnv('OPR_EXECUTOR_ENV', Http::MODE_TYPE_PRODUCTION));


### PR DESCRIPTION
With new coroutine style, default 128MB no longer fits the needs.