### PR TITLE
Clarify active runtime ID usage in the executor

### DIFF
--- a/tests/ExecutorTest.php
+++ b/tests/ExecutorTest.php
@@ -152,12 +152,12 @@ final class ExecutorTest extends TestCase
         $response = $this->client->call(Client::METHOD_GET, '/runtimes', [], []);
         $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertEquals(1, count($response['body']));
-        $this->assertEquals('test-build', $response['body'][0]['name']);
+        $this->assertStringEndsWith('test-build', $response['body'][0]['name']);
 
         /** Get runtime */
         $response = $this->client->call(Client::METHOD_GET, '/runtimes/test-build', [], []);
         $this->assertEquals(200, $response['headers']['status-code']);
-        $this->assertEquals('test-build', $response['body']['name']);
+        $this->assertStringEndsWith('test-build', $response['body']['name']);
 
         /** Delete runtime */
         $response = $this->client->call(Client::METHOD_DELETE, '/runtimes/test-build', [], []);


### PR DESCRIPTION
The runtimeId will be the ID passed into the executor. From there, the runtimeName will be the hostname + runtimeId. We want to prefix with hostname to support multiple executors on the same machine.

The runtimeName will be used for the container name and the active runtimes table.

Confirmed building works:

<img width="1208" alt="image" src="https://github.com/open-runtimes/executor/assets/1477010/f2078476-f0e5-493e-ba06-a0055dc5d5ba">

Confirmed executing works:

<img width="1227" alt="image" src="https://github.com/open-runtimes/executor/assets/1477010/e08fa779-57b2-4dd5-beae-d5e8ff97084f">
