### PR TITLE
Fix: Remove locahost dns lookup

### DIFF
--- a/app/http.php
+++ b/app/http.php
@@ -761,7 +761,7 @@ Http::post('/v1/runtimes/:runtimeId/executions')
                         'runtimeEntrypoint' => $runtimeEntrypoint
                     ]);
 
-                    \curl_setopt($ch, CURLOPT_URL, "http://localhost/v1/runtimes");
+                    \curl_setopt($ch, CURLOPT_URL, "http://127.0.01/v1/runtimes");
                     \curl_setopt($ch, CURLOPT_POST, true);
                     \curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
                     \curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);


### PR DESCRIPTION
Localhost could refer to IPV4 or IPV6. It's extra lookup, slowing things down tiny-bit. Using IP directly is improved performance. Very little but something.