### PR TITLE
Fix: accept headers

### DIFF
--- a/app/http.php
+++ b/app/http.php
@@ -1218,7 +1218,7 @@ Http::post('/v1/runtimes/:runtimeId/executions')
             $isJson = false;
 
             foreach ($acceptTypes as $acceptType) {
-                if (\str_starts_with($acceptType, 'application/')) {
+                if (\str_starts_with($acceptType, 'application/json') || \str_starts_with($acceptType, 'application/*')) {
                     $isJson = true;
                     break;
                 }

--- a/app/http.php
+++ b/app/http.php
@@ -1214,7 +1214,7 @@ Http::post('/v1/runtimes/:runtimeId/executions')
             $runtime['updated'] = \microtime(true);
             $activeRuntimes->set($runtimeName, $runtime);
 
-            $acceptTypes = \explode(',', $request->getHeader('accept', 'multipart/form-data'));
+            $acceptTypes = \explode(', ', $request->getHeader('accept', 'multipart/form-data'));
             $isJson = false;
 
             foreach ($acceptTypes as $acceptType) {

--- a/app/http.php
+++ b/app/http.php
@@ -1214,10 +1214,17 @@ Http::post('/v1/runtimes/:runtimeId/executions')
             $runtime['updated'] = \microtime(true);
             $activeRuntimes->set($runtimeName, $runtime);
 
-            $acceptType = $request->getHeader('accept', 'multipart/form-data');
-            if (\str_starts_with($acceptType, 'application/json')) {
-                // JSON response
+            $acceptTypes = \explode(',', $request->getHeader('accept', 'multipart/form-data'));
+            $isJson = false;
 
+            foreach ($acceptTypes as $acceptType) {
+                if (\str_starts_with($acceptType, 'application/')) {
+                    $isJson = true;
+                    break;
+                }
+            }
+
+            if ($isJson) {
                 $executionString = \json_encode($execution, JSON_UNESCAPED_UNICODE);
                 if (!$executionString) {
                     throw new Exception('Execution resulted in binary response, but JSON response does not allow binaries. Use "Accept: multipart/form-data" header to support binaries.', 400);

--- a/tests/ExecutorTest.php
+++ b/tests/ExecutorTest.php
@@ -271,15 +271,94 @@ final class ExecutorTest extends TestCase
 
         /** Execution with / at beginning of path */
         $response = $this->client->call(Client::METHOD_POST, '/runtimes/test-exec-coldstart/executions', [], [
-           'source' => $data['path'],
-           'entrypoint' => 'index.php',
-           'path' => '/v1/users',
-           'image' => 'openruntimes/php:v4-8.1',
-           'runtimeEntrypoint' => 'cp /tmp/code.tar.gz /mnt/code/code.tar.gz && nohup helpers/start.sh "' . $command . '"'
+            'source' => $data['path'],
+            'entrypoint' => 'index.php',
+            'path' => '/v1/users',
+            'image' => 'openruntimes/php:v4-8.1',
+            'runtimeEntrypoint' => 'cp /tmp/code.tar.gz /mnt/code/code.tar.gz && nohup helpers/start.sh "' . $command . '"'
         ]);
 
         $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertEquals("200", $response['body']['statusCode']);
+
+        /** Execution with different accept headers */
+        $response = $this->client->call(Client::METHOD_POST, '/runtimes/test-exec-coldstart/executions', [
+            'accept' => 'application/json'
+        ], [
+            'source' => $data['path'],
+            'entrypoint' => 'index.php',
+            'path' => '/v1/users',
+            'image' => 'openruntimes/php:v4-8.1',
+            'runtimeEntrypoint' => 'cp /tmp/code.tar.gz /mnt/code/code.tar.gz && nohup helpers/start.sh "' . $command . '"'
+        ]);
+
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertEquals('application/json', $response['headers']['content-type']);
+
+        $response = $this->client->call(Client::METHOD_POST, '/runtimes/test-exec-coldstart/executions', [
+            'accept' => 'application/*'
+        ], [
+            'source' => $data['path'],
+            'entrypoint' => 'index.php',
+            'path' => '/v1/users',
+            'image' => 'openruntimes/php:v4-8.1',
+            'runtimeEntrypoint' => 'cp /tmp/code.tar.gz /mnt/code/code.tar.gz && nohup helpers/start.sh "' . $command . '"'
+        ]);
+
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertEquals('application/json', $response['headers']['content-type']);
+
+        $response = $this->client->call(Client::METHOD_POST, '/runtimes/test-exec-coldstart/executions', [
+            'accept' => 'text/plain, application/json'
+        ], [
+            'source' => $data['path'],
+            'entrypoint' => 'index.php',
+            'path' => '/v1/users',
+            'image' => 'openruntimes/php:v4-8.1',
+            'runtimeEntrypoint' => 'cp /tmp/code.tar.gz /mnt/code/code.tar.gz && nohup helpers/start.sh "' . $command . '"'
+        ]);
+
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertEquals('application/json', $response['headers']['content-type']);
+
+        $response = $this->client->call(Client::METHOD_POST, '/runtimes/test-exec-coldstart/executions', [
+            'accept' => 'application/xml'
+        ], [
+            'source' => $data['path'],
+            'entrypoint' => 'index.php',
+            'path' => '/v1/users',
+            'image' => 'openruntimes/php:v4-8.1',
+            'runtimeEntrypoint' => 'cp /tmp/code.tar.gz /mnt/code/code.tar.gz && nohup helpers/start.sh "' . $command . '"'
+        ]);
+
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertStringStartsWith('multipart/form-data', $response['headers']['content-type']);
+
+        $response = $this->client->call(Client::METHOD_POST, '/runtimes/test-exec-coldstart/executions', [
+            'accept' => 'text/plain'
+        ], [
+            'source' => $data['path'],
+            'entrypoint' => 'index.php',
+            'path' => '/v1/users',
+            'image' => 'openruntimes/php:v4-8.1',
+            'runtimeEntrypoint' => 'cp /tmp/code.tar.gz /mnt/code/code.tar.gz && nohup helpers/start.sh "' . $command . '"'
+        ]);
+
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertStringStartsWith('multipart/form-data', $response['headers']['content-type']);
+
+        $response = $this->client->call(Client::METHOD_POST, '/runtimes/test-exec-coldstart/executions', [
+            'accept' => '*/*'
+        ], [
+            'source' => $data['path'],
+            'entrypoint' => 'index.php',
+            'path' => '/v1/users',
+            'image' => 'openruntimes/php:v4-8.1',
+            'runtimeEntrypoint' => 'cp /tmp/code.tar.gz /mnt/code/code.tar.gz && nohup helpers/start.sh "' . $command . '"'
+        ]);
+
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertStringStartsWith('multipart/form-data', $response['headers']['content-type']);
 
         /** Delete runtime */
         $response = $this->client->call(Client::METHOD_DELETE, '/runtimes/test-exec-coldstart', [], []);


### PR DESCRIPTION
Accept header syntax didnt allow `, `, and `*`. Both now supported properly, and tested.