### PR TITLE
Fix: cleanup tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,4 +29,4 @@ jobs:
 
     - name: Run Tests
       run: |
-        docker run --rm -v $PWD:/app -v  /var/run/docker.sock:/var/run/docker.sock --network openruntimes-runtimes -w /app phpswoole/swoole:5.1.2-php8.3-alpine sh -c "apk update && apk add docker-cli && composer install --profile --ignore-platform-reqs && composer test"
+        docker run --rm -v $PWD:/app -v /tmp:/tmp -v /var/run/docker.sock:/var/run/docker.sock --network openruntimes-runtimes -w /app phpswoole/swoole:5.1.2-php8.3-alpine sh -c "apk update && apk add docker-cli && composer install --profile --ignore-platform-reqs && composer test"

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "utopia-php/framework": "0.34.*",
         "utopia-php/logger": "0.6.*",
         "utopia-php/cli": "0.16.*",
-        "utopia-php/storage": "0.18.4",
+        "utopia-php/storage": "0.18.*",
         "utopia-php/dsn": "0.1.*",
         "utopia-php/registry": "0.5.*",
         "utopia-php/preloader": "0.2.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "19fe70910a8bd439efe6aa78329b7a7f",
+    "content-hash": "a9abfb0c45c71f0c0deaa0bb616ab27e",
     "packages": [
         {
             "name": "appwrite/php-runtimes",

--- a/composer.lock
+++ b/composer.lock
@@ -417,16 +417,16 @@
         },
         {
             "name": "utopia-php/storage",
-            "version": "0.18.4",
+            "version": "0.18.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/storage.git",
-                "reference": "94ab8758fabcefee5c5fa723616e45719833f922"
+                "reference": "7d355c5e3ccc8ecebc0266f8ddd30088a43be919"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/storage/zipball/94ab8758fabcefee5c5fa723616e45719833f922",
-                "reference": "94ab8758fabcefee5c5fa723616e45719833f922",
+                "url": "https://api.github.com/repos/utopia-php/storage/zipball/7d355c5e3ccc8ecebc0266f8ddd30088a43be919",
+                "reference": "7d355c5e3ccc8ecebc0266f8ddd30088a43be919",
                 "shasum": ""
             },
             "require": {
@@ -466,9 +466,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/storage/issues",
-                "source": "https://github.com/utopia-php/storage/tree/0.18.4"
+                "source": "https://github.com/utopia-php/storage/tree/0.18.5"
             },
-            "time": "2024-04-02T08:24:09+00:00"
+            "time": "2024-09-04T08:57:27+00:00"
         },
         {
             "name": "utopia-php/system",

--- a/composer.lock
+++ b/composer.lock
@@ -726,16 +726,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.1.0",
+            "version": "v5.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1"
+                "reference": "23c79fbbfb725fb92af9bcf41065c8e9a0d49ddb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/683130c2ff8c2739f4822ff7ac5c873ec529abd1",
-                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/23c79fbbfb725fb92af9bcf41065c8e9a0d49ddb",
+                "reference": "23c79fbbfb725fb92af9bcf41065c8e9a0d49ddb",
                 "shasum": ""
             },
             "require": {
@@ -778,9 +778,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.1.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.2.0"
             },
-            "time": "2024-07-01T20:03:41+00:00"
+            "time": "2024-09-15T16:40:33+00:00"
         },
         {
             "name": "phar-io/manifest",

--- a/tests/ExecutorTest.php
+++ b/tests/ExecutorTest.php
@@ -140,10 +140,10 @@ final class ExecutorTest extends TestCase
         $this->assertIsFloat($response['body']['startTime']);
         $this->assertIsInt($response['body']['size']);
 
-        /** Ensure build folder cleanup */
+        /** Ensure build folder exists (container still running) */
         $tmpFolderPath = '/tmp/executor-test-build';
-        $this->assertFalse(\is_dir($tmpFolderPath));
-        $this->assertFalse(\file_exists($tmpFolderPath));
+        $this->assertTrue(\is_dir($tmpFolderPath));
+        $this->assertTrue(\file_exists($tmpFolderPath));
 
         /** List runtimes */
         $response = $this->client->call(Client::METHOD_GET, '/runtimes', [], []);
@@ -172,6 +172,17 @@ final class ExecutorTest extends TestCase
         $response = $this->client->call(Client::METHOD_POST, '/runtimes', [], $params);
         $this->assertEquals(201, $response['headers']['status-code']);
 
+        /** Ensure build folder cleanup */
+        $tmpFolderPath = '/tmp/executor-test-build-selfdelete';
+        $this->assertFalse(\is_dir($tmpFolderPath));
+        $this->assertFalse(\file_exists($tmpFolderPath));
+
+        /** List runtimes */
+        $response = $this->client->call(Client::METHOD_GET, '/runtimes', [], []);
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertEquals(0, count($response['body'])); // Not 1, it was auto-removed
+
+        /** Failure getRuntime */
         $response = $this->client->call(Client::METHOD_GET, '/runtimes/test-build-selfdelete', [], []);
         $this->assertEquals(404, $response['headers']['status-code']);
 
@@ -448,7 +459,7 @@ final class ExecutorTest extends TestCase
 
         /** Build runtime */
         $params = [
-            'runtimeId' => 'test-build',
+            'runtimeId' => 'test-build-logs',
             'source' => '/storage/functions/php-build-logs/code.tar.gz',
             'destination' => '/storage/builds/test',
             'entrypoint' => 'index.php',
@@ -469,7 +480,7 @@ final class ExecutorTest extends TestCase
 
         /** Build runtime */
         $params = [
-            'runtimeId' => 'test-build',
+            'runtimeId' => 'test-build-logs',
             'source' => '/storage/functions/php-build-logs/code.tar.gz',
             'destination' => '/storage/builds/test',
             'entrypoint' => 'index.php',
@@ -487,7 +498,7 @@ final class ExecutorTest extends TestCase
 
         /** Build runtime */
         $params = [
-            'runtimeId' => 'test-build',
+            'runtimeId' => 'test-build-logs',
             'source' => '/storage/functions/php-build-logs/code.tar.gz',
             'destination' => '/storage/builds/test',
             'entrypoint' => 'index.php',
@@ -508,7 +519,7 @@ final class ExecutorTest extends TestCase
 
         /** Build runtime */
         $params = [
-            'runtimeId' => 'test-build',
+            'runtimeId' => 'test-build-logs',
             'source' => '/storage/functions/php-build-logs/code.tar.gz',
             'destination' => '/storage/builds/test',
             'entrypoint' => 'index.php',

--- a/tests/ExecutorTest.php
+++ b/tests/ExecutorTest.php
@@ -3,11 +3,8 @@
 namespace Tests;
 
 use PHPUnit\Framework\TestCase;
-use Swoole\Runtime;
 use Swoole\Coroutine as Co;
 use Utopia\CLI\Console;
-
-Runtime::enableCoroutine(true, SWOOLE_HOOK_ALL);
 
 // TODO: @Meldiron Write more tests (validators mainly)
 // TODO: @Meldiron Health API tests
@@ -120,10 +117,7 @@ final class ExecutorTest extends TestCase
         $this->client->setKey($this->key);
     }
 
-    /**
-     * @return array<string,mixed>
-     */
-    public function testBuild(): array
+    public function testBuild(): void
     {
         $output = '';
         Console::execute('cd /app/tests/resources/functions/php && tar --exclude code.tar.gz -czf code.tar.gz .', '', $output);
@@ -135,7 +129,7 @@ final class ExecutorTest extends TestCase
             'destination' => '/storage/builds/test',
             'entrypoint' => 'index.php',
             'image' => 'openruntimes/php:v4-8.1',
-            'command' => 'tar -zxf /tmp/code.tar.gz -C /mnt/code && helpers/build.sh "composer install"'
+            'command' => 'tar -zxf /tmp/code.tar.gz -C /mnt/code && helpers/build.sh "composer install"',
         ];
 
         $response = $this->client->call(Client::METHOD_POST, '/runtimes', [], $params);
@@ -146,7 +140,10 @@ final class ExecutorTest extends TestCase
         $this->assertIsFloat($response['body']['startTime']);
         $this->assertIsInt($response['body']['size']);
 
-        $buildPath = $response['body']['path'];
+        /** Ensure build folder cleanup */
+        $tmpFolderPath = '/tmp/executor-test-build';
+        $this->assertFalse(\is_dir($tmpFolderPath));
+        $this->assertFalse(\file_exists($tmpFolderPath));
 
         /** List runtimes */
         $response = $this->client->call(Client::METHOD_GET, '/runtimes', [], []);
@@ -205,21 +202,34 @@ final class ExecutorTest extends TestCase
 
         $response = $this->client->call(Client::METHOD_POST, '/runtimes', [], $params);
         $this->assertEquals(500, $response['headers']['status-code']);
-
-        return ['path' => $buildPath];
     }
 
-    /**
-     * @depends testBuild
-     *
-     * @param array<string,mixed> $data
-     */
-    public function testExecute(array $data): void
+    public function testExecute(): void
     {
+        /** Prepare function */
+        $output = '';
+        Console::execute('cd /app/tests/resources/functions/php && tar --exclude code.tar.gz -czf code.tar.gz .', '', $output);
+
+        $params = [
+            'runtimeId' => 'test-build',
+            'source' => '/storage/functions/php/code.tar.gz',
+            'destination' => '/storage/builds/test',
+            'entrypoint' => 'index.php',
+            'image' => 'openruntimes/php:v4-8.1',
+            'command' => 'tar -zxf /tmp/code.tar.gz -C /mnt/code && helpers/build.sh "composer install"',
+        ];
+
+        $response = $this->client->call(Client::METHOD_POST, '/runtimes', [], $params);
+        $this->assertEquals(201, $response['headers']['status-code']);
+        $this->assertNotEmpty(201, $response['body']['path']);
+
+        $buildPath = $response['body']['path'];
+
+        /** Test executions */
         $command = 'php src/server.php';
         $params = [
             'runtimeId' => 'test-exec',
-            'source' => $data['path'],
+            'source' => $buildPath,
             'entrypoint' => 'index.php',
             'image' => 'openruntimes/php:v4-8.1',
             'runtimeEntrypoint' => 'cp /tmp/code.tar.gz /mnt/code/code.tar.gz && nohup helpers/start.sh "' . $command . '"'
@@ -232,6 +242,11 @@ final class ExecutorTest extends TestCase
 
         $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertEquals(200, $response['body']['statusCode']);
+
+        $logsFolderPath = '/tmp/executor-test-exec/logs';
+
+        $this->assertTrue(\is_dir($logsFolderPath));
+        $this->assertCount(2, \scandir($logsFolderPath) ?: []); // . and .. are always present
 
         /** Execute on cold-started runtime */
         $response = $this->client->call(Client::METHOD_POST, '/runtimes/test-exec/executions', [], [
@@ -249,7 +264,7 @@ final class ExecutorTest extends TestCase
 
         /** Execute on new runtime */
         $response = $this->client->call(Client::METHOD_POST, '/runtimes/test-exec-coldstart/executions', [], [
-            'source' => $data['path'],
+            'source' => $buildPath,
             'entrypoint' => 'index.php',
             'image' => 'openruntimes/php:v4-8.1',
             'runtimeEntrypoint' => 'cp /tmp/code.tar.gz /mnt/code/code.tar.gz && nohup helpers/start.sh "' . $command . '"'
@@ -259,7 +274,7 @@ final class ExecutorTest extends TestCase
 
         /** Execution without / at beginning of path */
         $response = $this->client->call(Client::METHOD_POST, '/runtimes/test-exec-coldstart/executions', [], [
-            'source' => $data['path'],
+            'source' => $buildPath,
             'entrypoint' => 'index.php',
             'path' => 'v1/users',
             'image' => 'openruntimes/php:v4-8.1',
@@ -271,7 +286,7 @@ final class ExecutorTest extends TestCase
 
         /** Execution with / at beginning of path */
         $response = $this->client->call(Client::METHOD_POST, '/runtimes/test-exec-coldstart/executions', [], [
-            'source' => $data['path'],
+            'source' => $buildPath,
             'entrypoint' => 'index.php',
             'path' => '/v1/users',
             'image' => 'openruntimes/php:v4-8.1',
@@ -285,7 +300,7 @@ final class ExecutorTest extends TestCase
         $response = $this->client->call(Client::METHOD_POST, '/runtimes/test-exec-coldstart/executions', [
             'accept' => 'application/json'
         ], [
-            'source' => $data['path'],
+            'source' => $buildPath,
             'entrypoint' => 'index.php',
             'path' => '/v1/users',
             'image' => 'openruntimes/php:v4-8.1',
@@ -298,7 +313,7 @@ final class ExecutorTest extends TestCase
         $response = $this->client->call(Client::METHOD_POST, '/runtimes/test-exec-coldstart/executions', [
             'accept' => 'application/*'
         ], [
-            'source' => $data['path'],
+            'source' => $buildPath,
             'entrypoint' => 'index.php',
             'path' => '/v1/users',
             'image' => 'openruntimes/php:v4-8.1',
@@ -311,7 +326,7 @@ final class ExecutorTest extends TestCase
         $response = $this->client->call(Client::METHOD_POST, '/runtimes/test-exec-coldstart/executions', [
             'accept' => 'text/plain, application/json'
         ], [
-            'source' => $data['path'],
+            'source' => $buildPath,
             'entrypoint' => 'index.php',
             'path' => '/v1/users',
             'image' => 'openruntimes/php:v4-8.1',
@@ -324,7 +339,7 @@ final class ExecutorTest extends TestCase
         $response = $this->client->call(Client::METHOD_POST, '/runtimes/test-exec-coldstart/executions', [
             'accept' => 'application/xml'
         ], [
-            'source' => $data['path'],
+            'source' => $buildPath,
             'entrypoint' => 'index.php',
             'path' => '/v1/users',
             'image' => 'openruntimes/php:v4-8.1',
@@ -337,7 +352,7 @@ final class ExecutorTest extends TestCase
         $response = $this->client->call(Client::METHOD_POST, '/runtimes/test-exec-coldstart/executions', [
             'accept' => 'text/plain'
         ], [
-            'source' => $data['path'],
+            'source' => $buildPath,
             'entrypoint' => 'index.php',
             'path' => '/v1/users',
             'image' => 'openruntimes/php:v4-8.1',
@@ -350,7 +365,7 @@ final class ExecutorTest extends TestCase
         $response = $this->client->call(Client::METHOD_POST, '/runtimes/test-exec-coldstart/executions', [
             'accept' => '*/*'
         ], [
-            'source' => $data['path'],
+            'source' => $buildPath,
             'entrypoint' => 'index.php',
             'path' => '/v1/users',
             'image' => 'openruntimes/php:v4-8.1',


### PR DESCRIPTION
I added test that ensures build folders are cleaned up properly.

I also:
- Rewrite tests to not be dependent
- Removed unnecessary swoole configuration (was causing trouble when running non-streamed tests)