### PR TITLE
Feat: Runtime image logging

### DIFF
--- a/app/http.php
+++ b/app/http.php
@@ -125,6 +125,7 @@ $register->set('activeRuntimes', function () {
     $table->column('status', Table::TYPE_STRING, 256);
     $table->column('key', Table::TYPE_STRING, 1024);
     $table->column('listening', Table::TYPE_INT, 1);
+    $table->column('image', Table::TYPE_STRING, 1024);
     $table->create();
 
     return $table;
@@ -490,6 +491,7 @@ Http::post('/v1/runtimes')
 
         $runtimeHostname = \uniqid();
 
+        $log->addTag('image', $image);
         $log->addTag('version', $version);
         $log->addTag('runtimeId', $runtimeName);
 
@@ -515,6 +517,7 @@ Http::post('/v1/runtimes')
             'updated' => $startTime,
             'status' => 'pending',
             'key' => $secret,
+            'image' => $image,
         ]);
 
         /**
@@ -880,6 +883,7 @@ Http::post('/v1/runtimes/:runtimeId/executions')
 
             $runtimeName = System::getHostname() . '-' . $runtimeId;
 
+            $log->addTag('image', $image);
             $log->addTag('version', $version);
             $log->addTag('runtimeId', $runtimeName);
 
@@ -982,6 +986,9 @@ Http::post('/v1/runtimes/:runtimeId/executions')
 
             // Update swoole table
             $runtime = $activeRuntimes->get($runtimeName) ?? [];
+
+            $log->addTag('image', $runtime['image']);
+
             $runtime['updated'] = \time();
             $activeRuntimes->set($runtimeName, $runtime);
 


### PR DESCRIPTION
Include runtime image in log report. Helps identify if a problem is runtime-specific, or global (on executor).

- [x] Manual QA with Appwrite

![CleanShot 2024-09-30 at 09 55 36@2x](https://github.com/user-attachments/assets/3174a9ff-8c03-4210-8535-e3d33cf5cc86)

![CleanShot 2024-09-30 at 09 56 08@2x](https://github.com/user-attachments/assets/859cb3dd-2d85-442f-afd0-29afe9b223ba)

