### PR TITLE
fix: runtime ready loop

### DIFF
--- a/app/http.php
+++ b/app/http.php
@@ -832,9 +832,8 @@ Http::post('/v1/runtimes/:runtimeId/executions')
     ->inject('response')
     ->inject('request')
     ->inject('log')
-    ->inject('orchestration')
     ->action(
-        function (string $runtimeId, ?string $payload, string $path, string $method, mixed $headers, int $timeout, string $image, string $source, string $entrypoint, mixed $variables, float $cpus, int $memory, string $version, string $runtimeEntrypoint, bool $logging, string $restartPolicy, Table $activeRuntimes, Response $response, Request $request, Log $log, Orchestration $orchestration) {
+        function (string $runtimeId, ?string $payload, string $path, string $method, mixed $headers, int $timeout, string $image, string $source, string $entrypoint, mixed $variables, float $cpus, int $memory, string $version, string $runtimeEntrypoint, bool $logging, string $restartPolicy, Table $activeRuntimes, Response $response, Request $request, Log $log) {
             if (empty($payload)) {
                 $payload = '';
             }
@@ -1244,14 +1243,7 @@ Http::post('/v1/runtimes/:runtimeId/executions')
                         throw new Exception('Function timed out during cold start.', 400);
                     }
 
-                    $output = '';
-
-                    $online = $orchestration->execute(
-                        name: $runtimeName,
-                        command: ['sh', '-c', 'nc -zv localhost 3000'],
-                        output: $output,
-                    );
-
+                    $online = $validator->isValid($hostname . ':' . 3000);
                     if ($online) {
                         break;
                     }

--- a/app/http.php
+++ b/app/http.php
@@ -968,10 +968,10 @@ Http::post('/v1/runtimes/:runtimeId/executions')
                         // If the runtime has not yet attempted to start, it will return 500
                         if ($statusCode >= 500) {
                             $error = $body['message'];
-                    
+
                         // If the runtime fails to start, it will return 400, except for 409
                         // which indicates that the runtime is already being created
-                        } elseif ($statusCode >= 400 && $statusCode !== 409) { 
+                        } elseif ($statusCode >= 400 && $statusCode !== 409) {
                             $error = $body['message'];
                             throw new Exception('An internal curl error has occurred while starting runtime! Error Msg: ' . $error, 500);
                         } else {

--- a/app/http.php
+++ b/app/http.php
@@ -965,16 +965,21 @@ Http::post('/v1/runtimes/:runtimeId/executions')
                     if ($errNo === 0) {
                         $body = \json_decode($executorResponse, true);
 
+                        // If the runtime has not yet attempted to start, it will return 500
                         if ($statusCode >= 500) {
                             $error = $body['message'];
-                        // Continues to retry logic
-                        } elseif ($statusCode >= 400) {
+                    
+                        // If the runtime fails to start, it will return 400, except for 409
+                        // which indicates that the runtime is already being created
+                        } elseif ($statusCode >= 400 && $statusCode !== 409) { 
                             $error = $body['message'];
                             throw new Exception('An internal curl error has occurred while starting runtime! Error Msg: ' . $error, 500);
                         } else {
                             break;
                         }
-                    } elseif ($errNo !== 111) { // Connection Refused - see https://openswoole.com/docs/swoole-error-code
+
+                    // Connection refused - see https://openswoole.com/docs/swoole-error-code
+                    } elseif ($errNo !== 111) {
                         throw new Exception('An internal curl error has occurred while starting runtime! Error Msg: ' . $error, 500);
                     }
 

--- a/app/http.php
+++ b/app/http.php
@@ -1248,7 +1248,7 @@ Http::post('/v1/runtimes/:runtimeId/executions')
 
                     $online = $orchestration->execute(
                         name: $runtimeName,
-                        command: ['sh', '-c', 'nc -zv 3000'],
+                        command: ['sh', '-c', 'nc -zv localhost 3000'],
                         output: $output,
                     );
 

--- a/app/http.php
+++ b/app/http.php
@@ -1248,7 +1248,7 @@ Http::post('/v1/runtimes/:runtimeId/executions')
 
                     $status = $orchestration->execute(
                         name: $runtimeName,
-                        command: ['bash', '-c', '>/dev/tcp/localhost/3000'],
+                        command: ['bash', '-c', 'nc -zv localhost 3000'],
                         output: $output,
                         timeout: $timeout
                     );

--- a/app/http.php
+++ b/app/http.php
@@ -1248,7 +1248,7 @@ Http::post('/v1/runtimes/:runtimeId/executions')
 
                     $status = $orchestration->execute(
                         name: $runtimeName,
-                        command: ['bash', '-c', 'nc -zv localhost 3000'],
+                        command: ['sh', '-c', 'nc -zv 3000'],
                         output: $output,
                         timeout: $timeout
                     );

--- a/app/http.php
+++ b/app/http.php
@@ -1246,14 +1246,12 @@ Http::post('/v1/runtimes/:runtimeId/executions')
 
                     $output = '';
 
-                    $status = $orchestration->execute(
+                    $online = $orchestration->execute(
                         name: $runtimeName,
                         command: ['sh', '-c', 'nc -zv 3000'],
                         output: $output,
-                        timeout: $timeout
                     );
 
-                    $online = $status === 0;
                     if ($online) {
                         break;
                     }

--- a/tests/ExecutorTest.php
+++ b/tests/ExecutorTest.php
@@ -921,7 +921,8 @@ final class ExecutorTest extends TestCase
             'source' => $path,
             'entrypoint' => $entrypoint,
             'image' => $image,
-            'runtimeEntrypoint' => 'sh helpers/server.sh',
+            // start server but stay open container
+            'runtimeEntrypoint' => 'cp /tmp/code.tar.gz /mnt/code/code.tar.gz && nohup helpers/start.sh helpers/server.sh',
             'timeout' => 120,
             'variables' => [
                 'TEST_VARIABLE' => 'Variable secret'

--- a/tests/ExecutorTest.php
+++ b/tests/ExecutorTest.php
@@ -921,7 +921,6 @@ final class ExecutorTest extends TestCase
             'source' => $path,
             'entrypoint' => $entrypoint,
             'image' => $image,
-            // start server but stay open container
             'runtimeEntrypoint' => 'cp /tmp/code.tar.gz /mnt/code/code.tar.gz && nohup helpers/start.sh helpers/server.sh',
             'timeout' => 120,
             'variables' => [

--- a/tests/ExecutorTest.php
+++ b/tests/ExecutorTest.php
@@ -870,14 +870,14 @@ final class ExecutorTest extends TestCase
     public function provideCustomRuntimes(): array
     {
         return [
-            [ 'folder' => 'php', 'image' => 'openruntimes/php:v4-8.1', 'entrypoint' => 'index.php', 'buildCommand' => 'composer install', 'startCommand' => 'php src/server.php' ],
-            [ 'folder' => 'node', 'image' => 'openruntimes/node:v4-18.0', 'entrypoint' => 'index.js', 'buildCommand' => 'npm i', 'startCommand' => 'pm2 start src/server.js --no-daemon' ],
+            [ 'folder' => 'php', 'image' => 'openruntimes/php:v4-8.1', 'entrypoint' => 'index.php', 'buildCommand' => 'composer install' ],
+            [ 'folder' => 'node', 'image' => 'openruntimes/node:v4-18.0', 'entrypoint' => 'index.js', 'buildCommand' => 'npm i'],
             // [ 'folder' => 'deno', 'image' => 'openruntimes/deno:v4-1.24', 'entrypoint' => 'index.ts', 'buildCommand' => 'deno cache index.ts', 'startCommand' => 'denon start' ],
-            [ 'folder' => 'python', 'image' => 'openruntimes/python:v4-3.10', 'entrypoint' => 'index.py', 'buildCommand' => 'pip install --no-cache-dir -r requirements.txt', 'startCommand' => 'python3 src/server.py' ],
-            [ 'folder' => 'ruby', 'image' => 'openruntimes/ruby:v4-3.1', 'entrypoint' => 'index.rb', 'buildCommand' => '', 'startCommand' => 'bundle exec puma -b tcp://0.0.0.0:3000 -e production' ],
-            [ 'folder' => 'cpp', 'image' => 'openruntimes/cpp:v4-17', 'entrypoint' => 'index.cc', 'buildCommand' => '', 'startCommand' => 'src/function/cpp_runtime' ],
-            [ 'folder' => 'dart', 'image' => 'openruntimes/dart:v4-2.18', 'entrypoint' => 'lib/index.dart', 'buildCommand' => 'dart pub get', 'startCommand' => 'src/function/server' ],
-            [ 'folder' => 'dotnet', 'image' => 'openruntimes/dotnet:v4-6.0', 'entrypoint' => 'Index.cs', 'buildCommand' => '', 'startCommand' => 'dotnet src/function/DotNetRuntime.dll' ],
+            [ 'folder' => 'python', 'image' => 'openruntimes/python:v4-3.10', 'entrypoint' => 'index.py', 'buildCommand' => 'pip install -r requirements.txt'],
+            [ 'folder' => 'ruby', 'image' => 'openruntimes/ruby:v4-3.1', 'entrypoint' => 'index.rb', 'buildCommand' => ''],
+            [ 'folder' => 'cpp', 'image' => 'openruntimes/cpp:v4-17', 'entrypoint' => 'index.cc', 'buildCommand' => ''],
+            [ 'folder' => 'dart', 'image' => 'openruntimes/dart:v4-2.18', 'entrypoint' => 'lib/index.dart', 'buildCommand' => 'dart pub get'],
+            [ 'folder' => 'dotnet', 'image' => 'openruntimes/dotnet:v4-6.0', 'entrypoint' => 'Index.cs', 'buildCommand' => ''],
             // C++, Swift, Kotlin, Java missing on purpose
         ];
     }
@@ -889,7 +889,7 @@ final class ExecutorTest extends TestCase
      *
      * @dataProvider provideCustomRuntimes
      */
-    public function testCustomRuntimes(string $folder, string $image, string $entrypoint, string $buildCommand, string $startCommand): void
+    public function testCustomRuntimes(string $folder, string $image, string $entrypoint, string $buildCommand): void
     {
         // Prepare tar.gz files
         $output = '';
@@ -921,7 +921,7 @@ final class ExecutorTest extends TestCase
             'source' => $path,
             'entrypoint' => $entrypoint,
             'image' => $image,
-            'runtimeEntrypoint' => 'cp /tmp/code.tar.gz /mnt/code/code.tar.gz && nohup helpers/start.sh "' . $startCommand . '"',
+            'runtimeEntrypoint' => 'sh helpers/server.sh',
             'timeout' => 120,
             'variables' => [
                 'TEST_VARIABLE' => 'Variable secret'


### PR DESCRIPTION
When you make a request to create an execution, and the runtime doesn't exist yet, the executor tries to create the runtime first. If the runtime is already being created by another request (and exists in the `activeRuntimes` table with a 'pending' status), the /v1/runtimes endpoint returns a 409 Conflict error with the message:

```
A runtime with the same ID is already being created. Attempt a execution soon.
```

In the execution creation code, specifically in the loop that attempts to create the runtime, any HTTP response with a status code between 400 and 499 (inclusive) is treated as a fatal error, and it immediately throws an exception instead of retrying. This means that when the executor receives a 409 status code, it doesn't retry and instead exits the loop, leading to this error on sentry.

```
An internal curl error has occurred while starting runtime! Error Msg: A runtime with the same ID is already being created. Attempt a execution soon.
```

This PR excludes `409` responses from the check to avoid throwing an immediate exception.