### PR TITLE
feat: use nc healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN composer install --ignore-platform-reqs --optimize-autoloader \
 # Executor
 FROM openruntimes/base:0.1.0 as final
 
+RUN apk add --no-cache netcat-openbsd
+
 ARG OPR_EXECUTOR_VERSION
 ENV OPR_EXECUTOR_VERSION=$OPR_EXECUTOR_VERSION
 

--- a/app/http.php
+++ b/app/http.php
@@ -4,7 +4,6 @@ require_once __DIR__ . '/../vendor/autoload.php';
 
 use Appwrite\Runtimes\Runtimes;
 use OpenRuntimes\Executor\BodyMultipart;
-use OpenRuntimes\Executor\Validator\TCP;
 use OpenRuntimes\Executor\Usage;
 use Swoole\Process;
 use Swoole\Runtime;
@@ -1231,15 +1230,14 @@ Http::post('/v1/runtimes/:runtimeId/executions')
             if (empty($listening)) {
                 // Wait for cold-start to finish (app listening on port)
                 $pingStart = \microtime(true);
-                $validator = new TCP();
                 while (true) {
                     // If timeout is passed, stop and return error
                     if (\microtime(true) - $pingStart >= $timeout) {
                         throw new Exception('Function timed out during cold start.', 400);
                     }
 
-                    $online = $validator->isValid($hostname . ':' . 3000);
-                    if ($online) {
+                    $status = Console::execute('nc -z ' . $hostname . ' 3000', $output, $errNo);
+                    if ($status === 0) {
                         break;
                     }
 

--- a/app/http.php
+++ b/app/http.php
@@ -1236,7 +1236,7 @@ Http::post('/v1/runtimes/:runtimeId/executions')
                         throw new Exception('Function timed out during cold start.', 400);
                     }
 
-                    $status = Console::execute('nc -z ' . $hostname . ' 3000', $output, $errNo);
+                    $status = Console::execute('nc -z ' . $hostname . ' 3000', '', '');
                     if ($status === 0) {
                         break;
                     }

--- a/app/http.php
+++ b/app/http.php
@@ -1236,7 +1236,8 @@ Http::post('/v1/runtimes/:runtimeId/executions')
                         throw new Exception('Function timed out during cold start.', 400);
                     }
 
-                    $status = Console::execute('nc -z ' . $hostname . ' 3000', '', '');
+                    $output = '';
+                    $status = Console::execute('nc -z ' . $hostname . ' 3000', '', $output);
                     if ($status === 0) {
                         break;
                     }


### PR DESCRIPTION
Before executing functions, we perform attempt to create a TCP socket connection to the container hostname on port 3000. We think this might be unreliable, and result in dropped requests. This PR replaces that with a netcat command execution.

https://www.computerhope.com/unix/nc.htm#syntax