### PR TITLE
Feat: Allow local images

### DIFF
--- a/app/http.php
+++ b/app/http.php
@@ -1491,25 +1491,30 @@ run(function () use ($register) {
      */
     $allowList = empty(Http::getEnv('OPR_EXECUTOR_RUNTIMES')) ? [] : \explode(',', Http::getEnv('OPR_EXECUTOR_RUNTIMES'));
 
-    $runtimeVersions = \explode(',', Http::getEnv('OPR_EXECUTOR_RUNTIME_VERSIONS', 'v4') ?? 'v4');
-    foreach ($runtimeVersions as $runtimeVersion) {
-        Console::success("Pulling $runtimeVersion images...");
-        $runtimes = new Runtimes($runtimeVersion); // TODO: @Meldiron Make part of open runtimes
-        $runtimes = $runtimes->getAll(true, $allowList);
-        $callables = [];
-        foreach ($runtimes as $runtime) {
-            $callables[] = function () use ($runtime, $orchestration) {
-                Console::log('Warming up ' . $runtime['name'] . ' ' . $runtime['version'] . ' environment...');
-                $response = $orchestration->pull($runtime['image']);
-                if ($response) {
-                    Console::info("Successfully Warmed up {$runtime['name']} {$runtime['version']}!");
-                } else {
-                    Console::warning("Failed to Warmup {$runtime['name']} {$runtime['version']}!");
-                }
-            };
-        }
+    if(Http::isDevelopment()) {
+        // Useful to prevent auto-pulling from remote when testing local images
+        Console::info("Skipping image pulling in development mode.");
+    } else {
+        $runtimeVersions = \explode(',', Http::getEnv('OPR_EXECUTOR_RUNTIME_VERSIONS', 'v4') ?? 'v4');
+        foreach ($runtimeVersions as $runtimeVersion) {
+            Console::success("Pulling $runtimeVersion images...");
+            $runtimes = new Runtimes($runtimeVersion); // TODO: @Meldiron Make part of open runtimes
+            $runtimes = $runtimes->getAll(true, $allowList);
+            $callables = [];
+            foreach ($runtimes as $runtime) {
+                $callables[] = function () use ($runtime, $orchestration) {
+                    Console::log('Warming up ' . $runtime['name'] . ' ' . $runtime['version'] . ' environment...');
+                    $response = $orchestration->pull($runtime['image']);
+                    if ($response) {
+                        Console::info("Successfully Warmed up {$runtime['name']} {$runtime['version']}!");
+                    } else {
+                        Console::warning("Failed to Warmup {$runtime['name']} {$runtime['version']}!");
+                    }
+                };
+            }
 
-        batch($callables);
+            batch($callables);
+        }
     }
 
     Console::success("Image pulling finished.");


### PR DESCRIPTION
In development mode, prevent pulling images.

If no image is pulled yet, first run will take extra time. But this gives great benefit when local images are different than remote. Without this change, executor always pulls latest from remote, overriding any local changes.