### PR TITLE
Fix: Health endpoint compatibility

### DIFF
--- a/app/http.php
+++ b/app/http.php
@@ -1379,12 +1379,14 @@ Http::get('/v1/health')
     ->inject('response')
     ->action(function (Table $statsHost, Table $statsContainers, Response $response) {
         $output = [
+            'status' => 'pass',
             'runtimes' => [],
             'usage' => $statsHost->get('host', 'usage') ?? null
         ];
 
         foreach ($statsContainers as $hostname => $stat) {
             $output['runtimes'][$hostname] = [
+                'status' => 'pass',
                 'usage' => $stat['usage'] ?? null
             ];
         }


### PR DESCRIPTION
Reverts: https://github.com/open-runtimes/executor/pull/129

Re-adds status params expected by OPR Proxy version used on production