### PR TITLE
Fix error parsing for 'Cannot access offset of type string on string'

### DIFF
--- a/src/Executor/Runner/Docker.php
+++ b/src/Executor/Runner/Docker.php
@@ -627,8 +627,12 @@ class Docker extends Adapter
             $this->activeRuntimes->del($runtimeName);
 
             $message = '';
-            foreach ($output as $chunk) {
-                $message .= $chunk['content'];
+            if (isset($output['timestamp']) && isset($output['content']) && !isset($output[0])) {
+                $message = $output['content'];
+            } else {
+                foreach ($output as $chunk) {
+                    $message .= $chunk['content'];
+                }
             }
 
             throw new Exception($message, $th->getCode() ?: 500);


### PR DESCRIPTION
Instead of parsing the error correctly, build logs were showing `Cannot access offset of type string on string` error.

Fixed it and tested it manually:
![Screenshot 2025-05-05 at 3 57 30 PM](https://github.com/user-attachments/assets/34531b20-15c0-4d23-a5d9-cf58e5dafe5f)
