### PR TITLE
refactor: exceptions

### DIFF
--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -29,6 +29,12 @@ return [
         'message' => 'Runtime failed.',
         'code' => 400,
     ],
+    Exception::RUNTIME_TIMEOUT => [
+        'name' => Exception::RUNTIME_TIMEOUT,
+        'short' => 'Timeout',
+        'message' => 'Timed out waiting for runtime.',
+        'code' => 400,
+    ],
     Exception::RUNTIME_NOT_FOUND  => [
         'name' => Exception::RUNTIME_CONFLICT,
         'short' => 'Not found',
@@ -40,24 +46,6 @@ return [
         'short' => 'Conflict',
         'message' => 'Runtime already exists ',
         'code' => 409,
-    ],
-    Exception::RUNTIME_START_FAILED  => [
-        'name' => Exception::RUNTIME_START_FAILED,
-        'short' => 'Failed',
-        'message' => 'Runtime start failed.',
-        'code' => 500,
-    ],
-    Exception::RUNTIME_NOT_READY => [
-        'name' => Exception::RUNTIME_TIMEOUT,
-        'short' => 'Not ready',
-        'message' => 'Runtime not ready. Container not found.',
-        'code' => 500,
-    ],
-    Exception::RUNTIME_TIMEOUT => [
-        'name' => Exception::RUNTIME_TIMEOUT,
-        'short' => 'Timeout',
-        'message' => 'Timed out waiting for runtime.',
-        'code' => 504,
     ],
     /* Execution */
     Exception::EXECUTION_BAD_REQUEST => [
@@ -76,7 +64,7 @@ return [
         'name' => Exception::EXECUTION_TIMEOUT,
         'short' => 'Timeout',
         'message' => 'Timed out waiting for execution.',
-        'code' => 504,
+        'code' => 400,
     ],
     /* Logs */
     Exception::LOGS_TIMEOUT => [

--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -1,0 +1,101 @@
+<?php
+
+use OpenRuntimes\Executor\Exception;
+
+return [
+    /* General */
+    Exception::GENERAL_UNKNOWN => [
+        'name' => Exception::GENERAL_UNKNOWN,
+        'short' => 'Whoops',
+        'message' => 'Internal server error.',
+        'code' => 500,
+    ],
+    Exception::GENERAL_ROUTE_NOT_FOUND => [
+        'name' => Exception::GENERAL_ROUTE_NOT_FOUND,
+        'short' => 'Not found',
+        'message' => 'The requested route was not found.',
+        'code' => 404,
+    ],
+    Exception::GENERAL_UNAUTHORIZED => [
+        'name' => Exception::GENERAL_UNAUTHORIZED,
+        'short' => 'Unauthorized',
+        'message' => 'You are not authorized to access this resource.',
+        'code' => 401,
+    ],
+    /* Runtime */
+    Exception::RUNTIME_FAILED  => [
+        'name' => Exception::RUNTIME_FAILED,
+        'short' => 'Failed',
+        'message' => 'Runtime failed.',
+        'code' => 400,
+    ],
+    Exception::RUNTIME_NOT_FOUND  => [
+        'name' => Exception::RUNTIME_CONFLICT,
+        'short' => 'Not found',
+        'message' => 'Runtime not found',
+        'code' => 404,
+    ],
+    Exception::RUNTIME_CONFLICT  => [
+        'name' => Exception::RUNTIME_CONFLICT,
+        'short' => 'Conflict',
+        'message' => 'Runtime already exists ',
+        'code' => 409,
+    ],
+    Exception::RUNTIME_START_FAILED  => [
+        'name' => Exception::RUNTIME_START_FAILED,
+        'short' => 'Failed',
+        'message' => 'Runtime start failed.',
+        'code' => 500,
+    ],
+    Exception::RUNTIME_NOT_READY => [
+        'name' => Exception::RUNTIME_TIMEOUT,
+        'short' => 'Not ready',
+        'message' => 'Runtime not ready. Container not found.',
+        'code' => 500,
+    ],
+    Exception::RUNTIME_TIMEOUT => [
+        'name' => Exception::RUNTIME_TIMEOUT,
+        'short' => 'Timeout',
+        'message' => 'Timed out waiting for runtime.',
+        'code' => 504,
+    ],
+    /* Execution */
+    Exception::EXECUTION_BAD_REQUEST => [
+        'name' => Exception::EXECUTION_BAD_REQUEST,
+        'short' => 'Invalid request',
+        'message' => 'Execution request was invalid.',
+        'code' => 400,
+    ],
+    Exception::EXECUTION_BAD_JSON => [
+        'name' => Exception::EXECUTION_BAD_JSON,
+        'short' => 'Invalid response',
+        'message' => 'Execution resulted in binary response, but JSON response does not allow binaries. Use "Accept: multipart/form-data" header to support binaries.',
+        'code' => 400,
+    ],
+    Exception::EXECUTION_TIMEOUT => [
+        'name' => Exception::EXECUTION_TIMEOUT,
+        'short' => 'Timeout',
+        'message' => 'Timed out waiting for execution.',
+        'code' => 504,
+    ],
+    /* Logs */
+    Exception::LOGS_TIMEOUT => [
+        'name' => Exception::LOGS_TIMEOUT,
+        'short' => 'Timeout',
+        'message' => 'Timed out waiting for logs.',
+        'code' => 504,
+    ],
+    /* Command */
+    Exception::COMMAND_TIMEOUT => [
+        'name' => Exception::COMMAND_TIMEOUT,
+        'short' => 'Timeout',
+        'message' => 'Operation timed out.',
+        'code' => 500,
+    ],
+    Exception::COMMAND_FAILED => [
+        'name' => Exception::COMMAND_FAILED,
+        'short' => 'Failed',
+        'message' => 'Failed to execute command.',
+        'code' => 500,
+    ],
+];

--- a/app/controllers.php
+++ b/app/controllers.php
@@ -28,8 +28,6 @@ Http::get('/v1/runtimes/:runtimeId/logs')
     ->inject('log')
     ->inject('runner')
     ->action(function (string $runtimeId, string $timeoutStr, Response $response, Log $log, Runner $runner) {
-        $log->addTag('runtimeId', $runtimeId);
-
         $timeout = \intval($timeoutStr);
 
         $response->sendHeader('Content-Type', 'text/event-stream');
@@ -47,10 +45,7 @@ Http::post('/v1/runtimes/:runtimeId/commands')
     ->param('timeout', 600, new Integer(), 'Commands execution time in seconds.', true)
     ->inject('response')
     ->inject('runner')
-    ->inject('log')
-    ->action(function (string $runtimeId, string $command, int $timeout, Response $response, Runner $runner, Log $log) {
-        $log->addTag('runtimeId', $runtimeId);
-
+    ->action(function (string $runtimeId, string $command, int $timeout, Response $response, Runner $runner) {
         $output = $runner->executeCommand($runtimeId, $command, $timeout);
         $response->setStatusCode(Response::STATUS_CODE_OK)->json([ 'output' => $output ]);
     });
@@ -77,9 +72,6 @@ Http::post('/v1/runtimes')
     ->inject('log')
     ->inject('runner')
     ->action(function (string $runtimeId, string $image, string $entrypoint, string $source, string $destination, string $outputDirectory, array $variables, string $runtimeEntrypoint, string $command, int $timeout, bool $remove, float $cpus, int $memory, string $version, string $restartPolicy, Response $response, Log $log, Runner $runner) {
-        $log->addTag('runtimeId', $runtimeId);
-        $log->addTag('image', $image);
-
         $secret = \bin2hex(\random_bytes(16));
 
         /**
@@ -132,10 +124,7 @@ Http::get('/v1/runtimes/:runtimeId')
     ->param('runtimeId', '', new Text(64), 'Runtime unique ID.')
     ->inject('runner')
     ->inject('response')
-    ->inject('log')
-    ->action(function (string $runtimeId, Runner $runner, Response $response, Log $log) {
-        $log->addTag('runtimeId', $runtimeId);
-
+    ->action(function (string $runtimeId, Runner $runner, Response $response) {
         $runtimeName = System::getHostname() . '-' . $runtimeId;
         $response->setStatusCode(Response::STATUS_CODE_OK)->json($runner->getRuntime($runtimeName));
     });
@@ -148,8 +137,6 @@ Http::delete('/v1/runtimes/:runtimeId')
     ->inject('log')
     ->inject('runner')
     ->action(function (string $runtimeId, Response $response, Log $log, Runner $runner) {
-        $log->addTag('runtimeId', $runtimeId);
-
         $runner->deleteRuntime($runtimeId, $log);
         $response->setStatusCode(Response::STATUS_CODE_OK)->send();
     });
@@ -203,12 +190,6 @@ Http::post('/v1/runtimes/:runtimeId/executions')
             Log $log,
             Runner $runner
         ) {
-            $log->addTag('runtimeId', $runtimeId);
-            $log->addTag('image', $image);
-            $log->addTag('path', $path);
-            $log->addTag('method', $method);
-            $log->addTag('version', $version);
-
             // Extra parsers and validators to support both JSON and multipart
             $intParams = ['timeout', 'memory'];
             foreach ($intParams as $intParam) {

--- a/app/error.php
+++ b/app/error.php
@@ -1,94 +1,77 @@
 <?php
 
+use OpenRuntimes\Executor\Exception;
 use Utopia\CLI\Console;
 use Utopia\Http\Http;
 use Utopia\Logger\Log;
 use Utopia\Logger\Logger;
 use Utopia\Http\Response;
 
-function logError(Log $log, Throwable $error, string $action, Logger $logger = null): void
+function logError(Log $log, Throwable $error, ?Logger $logger = null): void
 {
     Console::error('[Error] Type: ' . get_class($error));
     Console::error('[Error] Message: ' . $error->getMessage());
     Console::error('[Error] File: ' . $error->getFile());
     Console::error('[Error] Line: ' . $error->getLine());
 
-    if ($logger && ($error->getCode() === 500 || $error->getCode() === 0)) {
+    if ($logger === null) {
+        return;
+    }
+
+    // Log everything, except those explicitly marked as not loggable
+    if ($error instanceof Exception && !$error->isLoggable()) {
+        return;
+    }
+
+    try {
         $log->setType(Log::TYPE_ERROR);
         $log->setMessage($error->getMessage());
-        $log->setAction($action);
-
+        $log->setAction("httpError");
         $log->addTag('code', \strval($error->getCode()));
         $log->addTag('verboseType', get_class($error));
-
         $log->addExtra('file', $error->getFile());
         $log->addExtra('line', $error->getLine());
         $log->addExtra('trace', $error->getTraceAsString());
-        // TODO: @Meldiron Uncomment, was warning: Undefined array key "file" in Sentry.php on line 68
-        // $log->addExtra('detailedTrace', $error->getTrace());
 
-        $responseCode = $logger->addLog($log);
-        Console::info('Executor log pushed with status code: ' . $responseCode);
+        $status = $logger->addLog($log);
+
+        Console::info("Pushed log with response status code: $status");
+    } catch (\Throwable $e) {
+        Console::error("Failed to push log: {$e->getMessage()}");
     }
 }
 
-
-/** Set callbacks */
 Http::error()
     ->inject('error')
     ->inject('logger')
     ->inject('response')
     ->inject('log')
     ->action(function (Throwable $error, ?Logger $logger, Response $response, Log $log) {
-        try {
-            logError($log, $error, "httpError", $logger);
-        } catch (Throwable) {
-            Console::warning('Unable to send log message');
-        }
+        logError($log, $error, $logger);
 
-        $version = Http::getEnv('OPR_EXECUTOR_VERSION', 'UNKNOWN');
-        $message = $error->getMessage();
-        $file = $error->getFile();
-        $line = $error->getLine();
-        $trace = $error->getTrace();
+        // Show all errors in development mode.
+        // Otherwise, only show Executor type exceptions, that are also marked as public.
+        $public = Http::isDevelopment() || ($error instanceof Exception && $error->isPublic());
+        $exception = $public ? $error : new Exception(Exception::GENERAL_UNKNOWN);
 
-        switch ($error->getCode()) {
-            case 400: // Error allowed publicly
-            case 401: // Error allowed publicly
-            case 402: // Error allowed publicly
-            case 403: // Error allowed publicly
-            case 404: // Error allowed publicly
-            case 406: // Error allowed publicly
-            case 409: // Error allowed publicly
-            case 412: // Error allowed publicly
-            case 425: // Error allowed publicly
-            case 429: // Error allowed publicly
-            case 501: // Error allowed publicly
-            case 503: // Error allowed publicly
-                $code = $error->getCode();
-                break;
-            default:
-                $code = 500; // All other errors get the generic 500 server error status code
-        }
-
-        $output = Http::isDevelopment() ? [
-            'message' => $message,
-            'code' => $code,
-            'file' => $file,
-            'line' => $line,
-            'trace' => \json_encode($trace, JSON_UNESCAPED_UNICODE) === false ? [] : $trace, // check for failing encode
-            'version' => $version
-        ] : [
-            'message' => $message,
-            'code' => $code,
-            'version' => $version
+        $output = [
+            'type' => $error instanceof Exception ? $error->getType() : Exception::GENERAL_UNKNOWN,
+            'message' => $exception->getMessage(),
+            'code' => $exception->getCode(),
+            'version' => Http::getEnv('OPR_EXECUTOR_VERSION', 'unknown')
         ];
+
+        // If in development, include some additional details.
+        if (Http::isDevelopment()) {
+            $output['file'] = $exception->getFile();
+            $output['line'] = $exception->getLine();
+            $output['trace'] = \json_encode($exception->getTrace(), JSON_UNESCAPED_UNICODE) === false ? [] : $exception->getTrace();
+        }
 
         $response
             ->addHeader('Cache-Control', 'no-cache, no-store, must-revalidate')
             ->addHeader('Expires', '0')
             ->addHeader('Pragma', 'no-cache')
-            ->setStatusCode($code);
-
-        $response->json($output);
+            ->setStatusCode($exception->getCode())
+            ->json($output);
     });

--- a/app/init.php
+++ b/app/init.php
@@ -1,5 +1,6 @@
 <?php
 
+use Utopia\Config\Config;
 use Utopia\Logger\Log;
 use Utopia\Logger\Logger;
 use Utopia\Logger\Adapter\AppSignal;
@@ -14,6 +15,8 @@ use Utopia\System\System;
 
 const MAX_LOG_SIZE = 5 * 1024 * 1024;
 const MAX_BUILD_LOG_SIZE = 1 * 1000 * 1000;
+
+Config::load('errors', __DIR__ . '/config/errors.php');
 
 // Setup Registry
 $register = new Registry();

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
     "utopia-php/preloader": "0.2.*",
     "utopia-php/system": "0.9.*",
     "utopia-php/orchestration": "0.14.*",
-    "appwrite/php-runtimes": "0.19.*"
+    "appwrite/php-runtimes": "0.19.*",
+    "utopia-php/config": "^0.2.2"
   },
   "require-dev": {
     "swoole/ide-helper": "5.1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "19acd63cdfc2cefbfe3e528918d30d73",
+    "content-hash": "e317d567e1a2fafdd587ef82a6a05d84",
     "packages": [
         {
             "name": "appwrite/php-runtimes",
@@ -1870,6 +1870,57 @@
                 "source": "https://github.com/utopia-php/cli/tree/0.16.0"
             },
             "time": "2023-08-05T13:13:08+00:00"
+        },
+        {
+            "name": "utopia-php/config",
+            "version": "0.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/utopia-php/config.git",
+                "reference": "a3d7bc0312d7150d5e04b1362dc34b2b136908cc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/utopia-php/config/zipball/a3d7bc0312d7150d5e04b1362dc34b2b136908cc",
+                "reference": "a3d7bc0312d7150d5e04b1362dc34b2b136908cc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "vimeo/psalm": "4.0.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Utopia\\Config\\": "src/Config"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eldad Fux",
+                    "email": "eldad@appwrite.io"
+                }
+            ],
+            "description": "A simple Config library to managing application config variables",
+            "keywords": [
+                "config",
+                "framework",
+                "php",
+                "upf",
+                "utopia"
+            ],
+            "support": {
+                "issues": "https://github.com/utopia-php/config/issues",
+                "source": "https://github.com/utopia-php/config/tree/0.2.2"
+            },
+            "time": "2020-10-24T09:49:09+00:00"
         },
         {
             "name": "utopia-php/dsn",

--- a/src/Executor/Exception.php
+++ b/src/Executor/Exception.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace OpenRuntimes\Executor;
+
+use Utopia\Config\Config;
+
+class Exception extends \RuntimeException
+{
+    /**
+     * Error Codes
+     *
+     * Naming the error types based on the following convention
+     * <ENTITY>_<ERROR_TYPE>
+     */
+    public const string GENERAL_UNKNOWN         = 'general_unknown';
+    public const string GENERAL_ROUTE_NOT_FOUND = 'general_route_not_found';
+    public const string GENERAL_UNAUTHORIZED    = 'general_unauthorized';
+
+    public const string EXECUTION_BAD_REQUEST = 'execution_bad_request';
+    public const string EXECUTION_TIMEOUT     = 'execution_timeout';
+    public const string EXECUTION_BAD_JSON    = 'execution_bad_josn';
+
+    public const string RUNTIME_NOT_FOUND    = 'runtime_not_found';
+    public const string RUNTIME_CONFLICT     = 'runtime_conflict';
+    public const string RUNTIME_START_FAILED = 'runtime_start_failed';
+    public const string RUNTIME_FAILED       = 'runtime_failed';
+    public const string RUNTIME_NOT_READY    = 'runtime_not_ready';
+    public const string RUNTIME_TIMEOUT      = 'runtime_timeout';
+
+    public const string LOGS_TIMEOUT = 'logs_timeout';
+
+    public const string COMMAND_TIMEOUT = 'command_timeout';
+    public const string COMMAND_FAILED = 'command_failed';
+
+    protected readonly string $type;
+    protected readonly string $short;
+    protected readonly bool $public;
+    protected readonly bool $loggable;
+
+    public function __construct(
+        string $type = Exception::GENERAL_UNKNOWN,
+        ?string $message = null,
+        ?int $code = null,
+        ?\Throwable $previous = null
+    ) {
+        $errors = Config::getParam('errors');
+
+        $this->type = $type;
+        $error = $errors[$type] ?? [];
+
+        $this->message = $message ?? $error['message'];
+        $this->code = $code ?? $error['code'] ?: 500;
+        $this->short = $error['short'] ?? '';
+
+        $this->public = $error['public'] ?? true;
+        $this->loggable = $error['loggable'] ?? true;
+
+        parent::__construct($this->message, $this->code, $previous);
+    }
+
+    /**
+     * Get the type of the exception.
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * Get the short version of the exception.
+     *
+     * @return string
+     */
+    public function getShort(): string
+    {
+        return $this->short;
+    }
+
+    /**
+     * Check whether the error message is public.
+     *
+     * @return bool
+     */
+    public function isPublic(): bool
+    {
+        return $this->public;
+    }
+
+    /**
+     * Check whether the error is loggable.
+     *
+     * @return bool
+     */
+    public function isLoggable(): bool
+    {
+        return $this->loggable;
+    }
+}

--- a/src/Executor/Exception.php
+++ b/src/Executor/Exception.php
@@ -18,13 +18,11 @@ class Exception extends \RuntimeException
 
     public const string EXECUTION_BAD_REQUEST = 'execution_bad_request';
     public const string EXECUTION_TIMEOUT     = 'execution_timeout';
-    public const string EXECUTION_BAD_JSON    = 'execution_bad_josn';
+    public const string EXECUTION_BAD_JSON    = 'execution_bad_json';
 
     public const string RUNTIME_NOT_FOUND    = 'runtime_not_found';
     public const string RUNTIME_CONFLICT     = 'runtime_conflict';
-    public const string RUNTIME_START_FAILED = 'runtime_start_failed';
     public const string RUNTIME_FAILED       = 'runtime_failed';
-    public const string RUNTIME_NOT_READY    = 'runtime_not_ready';
     public const string RUNTIME_TIMEOUT      = 'runtime_timeout';
 
     public const string LOGS_TIMEOUT = 'logs_timeout';
@@ -32,11 +30,21 @@ class Exception extends \RuntimeException
     public const string COMMAND_TIMEOUT = 'command_timeout';
     public const string COMMAND_FAILED = 'command_failed';
 
+    /**
+     * Properties
+     */
     protected readonly string $type;
     protected readonly string $short;
-    protected readonly bool $public;
-    protected readonly bool $loggable;
+    protected readonly bool $publish;
 
+    /**
+     * Constructor for the Exception class.
+     *
+     * @param string $type The type of exception. This will automatically set fallbacks for the other parameters.
+     * @param string|null $message The error message.
+     * @param int|null $code The error code.
+     * @param \Throwable|null $previous The previous exception.
+     */
     public function __construct(
         string $type = Exception::GENERAL_UNKNOWN,
         ?string $message = null,
@@ -52,8 +60,7 @@ class Exception extends \RuntimeException
         $this->code = $code ?? $error['code'] ?: 500;
         $this->short = $error['short'] ?? '';
 
-        $this->public = $error['public'] ?? true;
-        $this->loggable = $error['loggable'] ?? true;
+        $this->publish = $error['publish'] ?? true;
 
         parent::__construct($this->message, $this->code, $previous);
     }
@@ -79,22 +86,12 @@ class Exception extends \RuntimeException
     }
 
     /**
-     * Check whether the error message is public.
+     * Check whether the error message is publishable to logging systems (e.g. Sentry).
      *
      * @return bool
      */
-    public function isPublic(): bool
+    public function isPublishable(): bool
     {
-        return $this->public;
-    }
-
-    /**
-     * Check whether the error is loggable.
-     *
-     * @return bool
-     */
-    public function isLoggable(): bool
-    {
-        return $this->loggable;
+        return $this->publish;
     }
 }

--- a/src/Executor/Runner/Docker.php
+++ b/src/Executor/Runner/Docker.php
@@ -213,7 +213,7 @@ class Docker extends Adapter
             }
 
             if ($i === 9) {
-                throw new Exception(Exception::RUNTIME_NOT_READY);
+                throw new \Exception('Runtime not ready. Container not found.');
             }
 
             \usleep(500000); // 0.5s
@@ -336,7 +336,7 @@ class Docker extends Adapter
         });
 
         if (!$timerId) {
-            throw new \Exception('Failed to create timer', 500);
+            throw new \Exception('Failed to create timer');
         }
 
         Timer::clear($timerId);
@@ -462,7 +462,7 @@ class Docker extends Adapter
              */
             if (!empty($source)) {
                 if (!$sourceDevice->transfer($source, $tmpSource, $localDevice)) {
-                    throw new Exception(Exception::RUNTIME_START_FAILED, 'Failed to copy source code to temporary directory');
+                    throw new \Exception('Failed to copy source code to temporary directory');
                 };
             }
 
@@ -470,7 +470,7 @@ class Docker extends Adapter
              * Create the mount folder
              */
             if (!$localDevice->createDirectory(\dirname($tmpBuild))) {
-                throw new Exception(Exception::RUNTIME_START_FAILED, "Failed to create temporary directory");
+                throw new \Exception("Failed to create temporary directory");
             }
 
             $this->orchestration
@@ -520,7 +520,7 @@ class Docker extends Adapter
             );
 
             if (empty($containerId)) {
-                throw new Exception(Exception::RUNTIME_START_FAILED, 'Failed to create runtime');
+                throw new \Exception('Failed to create runtime');
             }
 
             /**
@@ -574,7 +574,7 @@ class Docker extends Adapter
             if (!empty($destination)) {
                 // Check if the build was successful by checking if file exists
                 if (!$localDevice->exists($tmpBuild)) {
-                    throw new Exception(Exception::RUNTIME_START_FAILED, 'Something went wrong when starting runtime.');
+                    throw new \Exception('Something went wrong when starting runtime.');
                 }
 
                 $size = $localDevice->getFileSize($tmpBuild);
@@ -584,7 +584,7 @@ class Docker extends Adapter
                 $path = $destinationDevice->getPath(\uniqid() . '.' . \pathinfo($tmpBuild, PATHINFO_EXTENSION));
 
                 if (!$localDevice->transfer($tmpBuild, $path, $destinationDevice)) {
-                    throw new Exception(Exception::RUNTIME_START_FAILED, 'Failed to move built code to storage');
+                    throw new \Exception('Failed to move built code to storage');
                 };
 
                 $container['path'] = $path;
@@ -656,7 +656,7 @@ class Docker extends Adapter
                 $message .= $chunk['content'];
             }
 
-            throw new Exception(Exception::RUNTIME_FAILED, $message, $th->getCode() ?: 500, $th);
+            throw new \Exception($message, $th->getCode() ?: 500, $th);
         }
 
         // Container cleanup

--- a/tests/ExecutorTest.php
+++ b/tests/ExecutorTest.php
@@ -201,50 +201,14 @@ class ExecutorTest extends TestCase
             'entrypoint' => 'index.php',
             'image' => 'openruntimes/php:v5-8.1',
             'command' => 'tar -zxf /tmp/code.tar.gz -C /mnt/code && bash helpers/build.sh "composer install"',
+            'remove' => true
         ];
-
-        $response = $this->client->call(Client::METHOD_POST, '/runtimes', [], $params);
-        $this->assertEquals(201, $response['headers']['status-code']);
-        $this->assertIsString($response['body']['path']);
-        $this->assertIsArray($response['body']['output']);
-        $this->assertIsFloat($response['body']['duration']);
-        $this->assertIsFloat($response['body']['startTime']);
-        $this->assertIsInt($response['body']['size']);
-
-        /** Ensure build folder exists (container still running) */
-        $tmpFolderPath = '/tmp/executor-test-build-' . $runtimeId;
-        $this->assertTrue(\is_dir($tmpFolderPath));
-        $this->assertTrue(\file_exists($tmpFolderPath));
-
-        /** List runtimes */
-        $response = $this->client->call(Client::METHOD_GET, '/runtimes', [], []);
-        $this->assertEquals(200, $response['headers']['status-code']);
-        $this->assertEquals(1, count($response['body']));
-        $this->assertStringEndsWith('test-build-' . $runtimeId, $response['body'][0]['name']);
-
-        /** Get runtime */
-        $response = $this->client->call(Client::METHOD_GET, '/runtimes/test-build-' . $runtimeId, [], []);
-        $this->assertEquals(200, $response['headers']['status-code']);
-        $this->assertStringEndsWith('test-build-' . $runtimeId, $response['body']['name']);
-
-        /** Delete runtime */
-        $response = $this->client->call(Client::METHOD_DELETE, '/runtimes/test-build-' . $runtimeId, [], []);
-        $this->assertEquals(200, $response['headers']['status-code']);
-
-        /** Delete non existent runtime */
-        $response = $this->client->call(Client::METHOD_DELETE, '/runtimes/test-build-' . $runtimeId, [], []);
-        $this->assertEquals(404, $response['headers']['status-code']);
-        $this->assertEquals('Runtime not found', $response['body']['message']);
-
-        /** Self-deleting build */
-        $params['runtimeId'] = 'test-build-selfdelete-' . $runtimeId;
-        $params['remove'] = true;
 
         $response = $this->client->call(Client::METHOD_POST, '/runtimes', [], $params);
         $this->assertEquals(201, $response['headers']['status-code']);
 
         /** Ensure build folder cleanup */
-        $tmpFolderPath = '/tmp/executor-test-build-selfdelete-' . $runtimeId;
+        $tmpFolderPath = '/tmp/executor-test-build-' . $runtimeId;
         $this->assertFalse(\is_dir($tmpFolderPath));
         $this->assertFalse(\file_exists($tmpFolderPath));
 
@@ -633,7 +597,6 @@ class ExecutorTest extends TestCase
         $buildPath = $response['body']['path'];
 
         /** Execute function */
-
         $response = $this->client->call(Client::METHOD_POST, '/runtimes/test-exec-restart-policy/executions', [], [
             'source' => $buildPath,
             'entrypoint' => 'index.php',
@@ -656,7 +619,6 @@ class ExecutorTest extends TestCase
         \sleep(5);
 
         /** Ensure restart policy */
-
         $output = [];
         \exec('docker logs executor-test-exec-restart-policy', $output);
         $output = \implode("\n", $output);


### PR DESCRIPTION
Refactor exception handling on Executor, inspired by exception handling on Appwrite and Cloud. We need this in order to easily declare new exceptions on Edge, and control when they should be public/logged.

Following the pattern in Appwrite:
- `config/errors.php `contains an array of error details for HTTP responses. Includes `publish` field to solve our recurring visibility issues with errors.
- `Exception.php` defines a HTTP layer exception, automatically populated using the defaults `config/errors.php`
- For now I've focused on 400 level errors, and kept the output of the errors the same, so tests are passing.

This is still not the perfect system, ideally we'd have domain level exceptions (mostly within Docker.php), and they should be caught and rethrown into HTTP layer exceptions (in the controller). But the PR is already large, so saving that for a follow up