### PR TITLE
chore: add test for head request

### DIFF
--- a/src/Executor/Runner/Docker.php
+++ b/src/Executor/Runner/Docker.php
@@ -641,14 +641,13 @@ class Docker extends Adapter
                 \sleep(2); // Allow time to read logs
             }
 
-            $localDevice->deletePath($tmpFolder);
-
             // Silently try to kill container
             try {
                 $this->orchestration->remove($runtimeName, true);
             } catch (Throwable $th) {
             }
 
+            $localDevice->deletePath($tmpFolder);
             $this->activeRuntimes->del($runtimeName);
 
             $message = '';
@@ -663,14 +662,13 @@ class Docker extends Adapter
         if ($remove) {
             \sleep(2); // Allow time to read logs
 
-            $localDevice->deletePath($tmpFolder);
-
             // Silently try to kill container
             try {
                 $this->orchestration->remove($runtimeName, true);
             } catch (Throwable $th) {
             }
 
+            $localDevice->deletePath($tmpFolder);
             $this->activeRuntimes->del($runtimeName);
         }
 
@@ -962,6 +960,7 @@ class Docker extends Adapter
 
             \curl_setopt($ch, CURLOPT_URL, "http://" . $hostname . ":3000" . $path);
             \curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+            \curl_setopt($ch, CURLOPT_NOBODY, $method === 'HEAD');
             \curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
             \curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
             \curl_setopt($ch, CURLOPT_HEADERFUNCTION, function ($curl, $header) use (&$responseHeaders) {

--- a/tests/ExecutorTest.php
+++ b/tests/ExecutorTest.php
@@ -362,7 +362,7 @@ class ExecutorTest extends TestCase
 
         $response = $this->client->call(Client::METHOD_POST, '/runtimes', [], $params);
         $this->assertEquals(201, $response['headers']['status-code']);
-        $this->assertNotEmpty(201, $response['body']['path']);
+        $this->assertNotEmpty($response['body']['path']);
 
         $buildPath = $response['body']['path'];
 
@@ -550,7 +550,7 @@ class ExecutorTest extends TestCase
 
         $response = $this->client->call(Client::METHOD_POST, '/runtimes', [], $params);
         $this->assertEquals(201, $response['headers']['status-code']);
-        $this->assertNotEmpty(201, $response['body']['path']);
+        $this->assertNotEmpty($response['body']['path']);
 
         $buildPath = $response['body']['path'];
 

--- a/tests/ExecutorTest.php
+++ b/tests/ExecutorTest.php
@@ -380,7 +380,6 @@ class ExecutorTest extends TestCase
         $this->assertEquals(201, $response['headers']['status-code']);
 
         $response = $this->client->call(Client::METHOD_POST, '/runtimes/test-exec/executions');
-
         $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertEquals(200, $response['body']['statusCode']);
 
@@ -446,6 +445,7 @@ class ExecutorTest extends TestCase
         $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertEquals('application/json', $response['headers']['content-type']);
 
+        /** accept application/* */
         $response = $this->client->call(Client::METHOD_POST, '/runtimes/test-exec-coldstart/executions', [
             'accept' => 'application/*'
         ], [
@@ -459,6 +459,7 @@ class ExecutorTest extends TestCase
         $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertEquals('application/json', $response['headers']['content-type']);
 
+        /** accept text/plain, application/json */
         $response = $this->client->call(Client::METHOD_POST, '/runtimes/test-exec-coldstart/executions', [
             'accept' => 'text/plain, application/json'
         ], [
@@ -472,6 +473,7 @@ class ExecutorTest extends TestCase
         $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertEquals('application/json', $response['headers']['content-type']);
 
+        /** accept application/xml */
         $response = $this->client->call(Client::METHOD_POST, '/runtimes/test-exec-coldstart/executions', [
             'accept' => 'application/xml'
         ], [
@@ -485,6 +487,7 @@ class ExecutorTest extends TestCase
         $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertStringStartsWith('multipart/form-data', $response['headers']['content-type']);
 
+        /** accept text/plain */
         $response = $this->client->call(Client::METHOD_POST, '/runtimes/test-exec-coldstart/executions', [
             'accept' => 'text/plain'
         ], [
@@ -498,6 +501,7 @@ class ExecutorTest extends TestCase
         $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertStringStartsWith('multipart/form-data', $response['headers']['content-type']);
 
+        /** accept */
         $response = $this->client->call(Client::METHOD_POST, '/runtimes/test-exec-coldstart/executions', [
             'accept' => '*/*'
         ], [
@@ -510,6 +514,18 @@ class ExecutorTest extends TestCase
 
         $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertStringStartsWith('multipart/form-data', $response['headers']['content-type']);
+
+        /** Execution with HEAD request */
+        $response = $this->client->call(Client::METHOD_POST, '/runtimes/test-exec-coldstart/executions', [], [
+            'source' => $buildPath,
+            'method' => 'HEAD',
+            'entrypoint' => 'index.php',
+            'path' => '/v1/users',
+            'image' => 'openruntimes/php:v5-8.1',
+            'runtimeEntrypoint' => 'cp /tmp/code.tar.gz /mnt/code/code.tar.gz && nohup helpers/start.sh "' . $command . '"'
+        ]);
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertEmpty($response['body']['body']);
 
         /** Delete runtime */
         $response = $this->client->call(Client::METHOD_DELETE, '/runtimes/test-exec-coldstart', [], []);


### PR DESCRIPTION
shifts `deletePath` function call to fix this warning:
`Warning: rmdir(/tmp/executor-test-log-stream-38bf304a/src/logging): Permission denied in /usr/local/vendor/utopia-php/storage/src/Storage/Device/Local.php on line 380`

passes locally
<img width="1215" height="616" alt="Screenshot 2025-08-26 at 11 41 56 AM" src="https://github.com/user-attachments/assets/8e14a1a2-66c6-4b0c-b85d-9defb645b363" />

<img width="615" height="327" alt="Screenshot 2025-08-26 at 11 46 26 AM" src="https://github.com/user-attachments/assets/ce22985c-0803-42c8-a751-860c75c04ab3" />
