### PR TITLE
Feat: coma-separated set-cookie

### DIFF
--- a/app/controllers.php
+++ b/app/controllers.php
@@ -261,16 +261,6 @@ Http::post('/v1/runtimes/:runtimeId/executions')
                 $log
             );
 
-            // Backwards compatibility for headers
-            $responseFormat = $request->getHeader('x-executor-response-format', '0.8.6'); // Last version without support for this header
-            if (version_compare($responseFormat, '0.9.0', '<')) {
-                $oldHeaders = [];
-                foreach ($execution['headers'] as $pair) {
-                    $oldHeaders[$pair['key']] = $pair['value'];
-                }
-                $execution['headers'] = $oldHeaders;
-            }
-
             $acceptTypes = \explode(', ', $request->getHeader('accept', 'multipart/form-data'));
             $isJson = false;
 

--- a/src/Executor/Runner/Docker.php
+++ b/src/Executor/Runner/Docker.php
@@ -971,10 +971,16 @@ class Docker extends Adapter
                 }
 
                 $key = strtolower(trim($header[0]));
-                $responseHeaders[$key] = trim($header[1]);
+                $value = trim($header[1]);
 
                 if (\in_array($key, ['x-open-runtimes-log-id'])) {
-                    $responseHeaders[$key] = \urldecode($responseHeaders[$key]);
+                    $value = \urldecode($value);
+                }
+
+                if (\array_key_exists($key, $responseHeaders)) {
+                    $responseHeaders[$key] .= ', ' . $value;
+                } else {
+                    $responseHeaders[$key] = $value;
                 }
 
                 return $len;

--- a/src/Executor/Runner/Docker.php
+++ b/src/Executor/Runner/Docker.php
@@ -971,13 +971,11 @@ class Docker extends Adapter
                 }
 
                 $key = strtolower(trim($header[0]));
-                $value = trim($header[1]);
+                $responseHeaders[$key] = trim($header[1]);
 
                 if (\in_array($key, ['x-open-runtimes-log-id'])) {
-                    $value = \urldecode($value);
+                    $responseHeaders[$key] = \urldecode($responseHeaders[$key]);
                 }
-
-                $responseHeaders[] = ['key' => $key, 'value' => $value ];
 
                 return $len;
             });
@@ -1025,14 +1023,7 @@ class Docker extends Adapter
             }
 
             // Extract logs and errors from file based on fileId in header
-            $logIdHeader = [];
-            foreach ($responseHeaders as $responseHeader) {
-                if ($responseHeader['key'] === 'x-open-runtimes-log-id') {
-                    $logIdHeader = $responseHeader;
-                    break;
-                }
-            }
-            $fileId = $logIdHeader['value'] ?? '';
+            $fileId = $responseHeaders['x-open-runtimes-log-id'] ?? '';
             $logs = '';
             $errors = '';
             if (!empty($fileId)) {
@@ -1067,12 +1058,12 @@ class Docker extends Adapter
             }
 
             $outputHeaders = [];
-            foreach ($responseHeaders as $pair) {
-                if (\str_starts_with($pair['key'], 'x-open-runtimes-')) {
+            foreach ($responseHeaders as $key => $value) {
+                if (\str_starts_with($key, 'x-open-runtimes-')) {
                     continue;
                 }
 
-                $outputHeaders[] = $pair;
+                $outputHeaders[$key] = $value;
             }
 
             return [

--- a/tests/Client.php
+++ b/tests/Client.php
@@ -18,7 +18,6 @@ class Client
     public const METHOD_TRACE = 'TRACE';
 
     protected bool $selfSigned = false;
-    protected string $version = '0.9.0';
     protected string $endpoint = '';
 
     /**
@@ -62,9 +61,6 @@ class Client
     public function call(string $method, string $path = '', array $headers = [], array $params = [], bool $decode = true, callable $callback = null): array
     {
         $headers            = array_merge($this->headers, $headers);
-        if (!\array_key_exists('x-executor-response-format', $headers)) {
-            $headers['x-executor-response-format'] = $this->version;
-        }
 
         $ch                 = curl_init($this->endpoint . $path . (($method == self::METHOD_GET && !empty($params)) ? '?' . http_build_query($params) : ''));
 

--- a/tests/ExecutorTest.php
+++ b/tests/ExecutorTest.php
@@ -382,7 +382,7 @@ class ExecutorTest extends TestCase
         $response = $this->client->call(Client::METHOD_POST, '/runtimes/test-exec/executions');
         $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertEquals(200, $response['body']['statusCode']);
-        $this->assertEquals('cookie1=value1; Path=/; HttpOnly; Secure; SameSite=Lax, cookie2=value2; Path=/; HttpOnly; Secure; SameSite=Lax', \json_decode($response['body']['headers'], true)['Set-Cookie']);
+        $this->assertEquals('cookie1=value1; Path=/; HttpOnly; Secure; SameSite=Lax, cookie2=value2; Path=/; HttpOnly; Secure; SameSite=Lax', \json_decode($response['body']['headers'], true)['set-cookie']);
 
         /** Execute on cold-started runtime */
         $response = $this->client->call(Client::METHOD_POST, '/runtimes/test-exec/executions', [], [
@@ -570,7 +570,7 @@ class ExecutorTest extends TestCase
         $this->assertEquals(200, $response['headers']['status-code']);
         $this->assertEquals(200, $response['body']['statusCode']);
         $this->assertStringContainsString('<p>OK</p>', $response['body']['body']);
-        $this->assertEquals('astroCookie1=astroValue1; Max-Age=1800; HttpOnly, astroCookie2=astroValue2; Max-Age=1800; HttpOnly', $response['body']['headers']['Set-Cookie']);
+        $this->assertEquals('astroCookie1=astroValue1; Max-Age=1800; HttpOnly, astroCookie2=astroValue2; Max-Age=1800; HttpOnly', \json_decode($response['body']['headers'], true)['set-cookie']);
 
         $this->assertNotEmpty($response['body']['logs']);
         $this->assertStringContainsString('Open runtimes log', $response['body']['logs']);

--- a/tests/resources/functions/php/index.php
+++ b/tests/resources/functions/php/index.php
@@ -22,6 +22,6 @@ return function ($context) use ($client) {
         'url' => $context->req->url,
         'todo' => $todo
     ], 200, [
-        'x-my-cookie' => 'cookieValue'
+        'Set-Cookie' => 'cookie1=value1; Path=/; HttpOnly; Secure; SameSite=Lax, cookie2=value2; Path=/; HttpOnly; Secure; SameSite=Lax'
     ]);
 };

--- a/tests/resources/sites/astro/src/pages/logs.astro
+++ b/tests/resources/sites/astro/src/pages/logs.astro
@@ -2,6 +2,17 @@
 console.log('Open runtimes log');
 console.log('A developer log');
 console.error('Open runtimes error');
+
+Astro.cookies.set('astroCookie1', 'astroValue1', {
+    httpOnly: true,
+    maxAge: 1800
+});
+
+Astro.cookies.set('astroCookie2', 'astroValue2', {
+    httpOnly: true,
+    maxAge: 1800
+});
+
 ---
 
 <p>OK</p>


### PR DESCRIPTION
Reverts breakng changes in 0.9.0, and adds support for multiple cookies in set-cookie

- Assertion in function was passing without main change too, but good to ensure
- Test in Astro cookie was NOT passing without main change


Main change:


https://github.com/open-runtimes/executor/blob/feat-set-cookie-comma-separtion/src/Executor/Runner/Docker.php#L980-L984
