### PR TITLE
Fix connection warning

### DIFF
--- a/src/Executor/Runner/Docker.php
+++ b/src/Executor/Runner/Docker.php
@@ -1278,7 +1278,7 @@ class Docker extends Adapter
                 try {
                     $this->orchestration->networkConnect($containerName, $network);
                     Console::success("Successfully connected executor '$containerName' to network '$network'");
-                } catch (Exception $e) {
+                } catch (\Throwable $e) {
                     Console::error("Failed to connect executor '$containerName' to network '$network': " . $e->getMessage());
                 }
             }


### PR DESCRIPTION
Connection should be just warning, in case it's just an "already exists", which can happen easily when running docker-compose and executor is already mentioned as part of network there.