### PR TITLE
Use DI resource container in executor

### DIFF
--- a/app/http.php
+++ b/app/http.php
@@ -47,7 +47,10 @@ Http::onStart()
             explode(',', System::getEnv('OPR_EXECUTOR_NETWORK') ?: 'openruntimes-runtimes'),
             $selfContainer->getName()
         );
-        $container->set('networks', new Dependency([], fn (): array => $network->getAvailable()));
+        $container->set(
+            'networks',
+            new Dependency([], fn (): array => $network->getAvailable())
+        );
 
         /* Pull images */
         $imagePuller->pull(explode(',', System::getEnv('OPR_EXECUTOR_IMAGES') ?: ''));

--- a/app/http.php
+++ b/app/http.php
@@ -10,6 +10,7 @@ use OpenRuntimes\Executor\Runner\Network;
 use Swoole\Runtime;
 use Utopia\Console;
 use Utopia\DI\Container;
+use Utopia\DI\Dependency;
 use Utopia\Http\Http;
 use Utopia\Http\Response;
 use Utopia\Http\Adapter\Swoole\Server;
@@ -46,7 +47,7 @@ Http::onStart()
             explode(',', System::getEnv('OPR_EXECUTOR_NETWORK') ?: 'openruntimes-runtimes'),
             $selfContainer->getName()
         );
-        $container->setResource('networks', fn (): array => $network->getAvailable());
+        $container->set('networks', new Dependency([], fn (): array => $network->getAvailable()));
 
         /* Pull images */
         $imagePuller->pull(explode(',', System::getEnv('OPR_EXECUTOR_IMAGES') ?: ''));

--- a/app/http.php
+++ b/app/http.php
@@ -74,7 +74,7 @@ run(function () use ($settings): void {
     /** @var Container $container */
     global $container;
 
-    $server = new Server('0.0.0.0', '80', $settings);
-    $http = new Http($server, 'UTC', $container);
+    $server = new Server('0.0.0.0', '80', $settings, $container);
+    $http = new Http($server, 'UTC');
     $http->start();
 });

--- a/app/http.php
+++ b/app/http.php
@@ -9,6 +9,7 @@ use OpenRuntimes\Executor\Runner\Maintenance;
 use OpenRuntimes\Executor\Runner\Network;
 use Swoole\Runtime;
 use Utopia\Console;
+use Utopia\DI\Container;
 use Utopia\Http\Http;
 use Utopia\Http\Response;
 use Utopia\Http\Adapter\Swoole\Server;
@@ -33,6 +34,9 @@ Http::onStart()
     ->inject('imagePuller')
     ->inject('maintenance')
     ->action(function (Orchestration $orchestration, Network $network, ImagePuller $imagePuller, Maintenance $maintenance): void {
+        /** @var Container $container */
+        global $container;
+
         /* Fetch own container information */
         $hostname = gethostname() ?: throw new \RuntimeException('Could not determine hostname');
         $selfContainer = $orchestration->list(['name' => $hostname])[0] ?? throw new \RuntimeException('Own container not found');
@@ -42,7 +46,7 @@ Http::onStart()
             explode(',', System::getEnv('OPR_EXECUTOR_NETWORK') ?: 'openruntimes-runtimes'),
             $selfContainer->getName()
         );
-        Http::setResource('networks', fn (): array => $network->getAvailable());
+        $container->setResource('networks', fn (): array => $network->getAvailable());
 
         /* Pull images */
         $imagePuller->pull(explode(',', System::getEnv('OPR_EXECUTOR_IMAGES') ?: ''));
@@ -63,7 +67,10 @@ Http::onRequest()
     });
 
 run(function () use ($settings): void {
+    /** @var Container $container */
+    global $container;
+
     $server = new Server('0.0.0.0', '80', $settings);
-    $http = new Http($server, 'UTC');
+    $http = new Http($server, 'UTC', $container);
     $http->start();
 });

--- a/app/http.php
+++ b/app/http.php
@@ -10,7 +10,6 @@ use OpenRuntimes\Executor\Runner\Network;
 use Swoole\Runtime;
 use Utopia\Console;
 use Utopia\DI\Container;
-use Utopia\DI\Dependency;
 use Utopia\Http\Http;
 use Utopia\Http\Response;
 use Utopia\Http\Adapter\Swoole\Server;
@@ -49,7 +48,8 @@ Http::onStart()
         );
         $container->set(
             'networks',
-            new Dependency([], fn (): array => $network->getAvailable())
+            fn (): array => $network->getAvailable(),
+            []
         );
 
         /* Pull images */

--- a/app/init.php
+++ b/app/init.php
@@ -25,8 +25,7 @@ $registry->set('runtimes', fn (): Runtimes => new Runtimes());
 
 $container->set(
     'runtimes',
-    fn (): Runtimes => $registry->get('runtimes'),
-    []
+    fn (): Runtimes => $registry->get('runtimes')
 );
 
 $container->set(
@@ -34,8 +33,7 @@ $container->set(
     fn (): Orchestration => new Orchestration(new DockerAPI(
         System::getEnv('OPR_EXECUTOR_DOCKER_HUB_USERNAME', ''),
         System::getEnv('OPR_EXECUTOR_DOCKER_HUB_PASSWORD', '')
-    )),
-    []
+    ))
 );
 
 $container->set(

--- a/app/init.php
+++ b/app/init.php
@@ -7,7 +7,6 @@ use OpenRuntimes\Executor\Runner\Network;
 use OpenRuntimes\Executor\Runner\Repository\Runtimes;
 use OpenRuntimes\Executor\Runner\Adapter;
 use Utopia\DI\Container;
-use Utopia\DI\Dependency;
 use Utopia\Orchestration\Adapter\DockerAPI;
 use Utopia\Orchestration\Orchestration;
 use Utopia\System\System;
@@ -26,45 +25,39 @@ $registry->set('runtimes', fn (): Runtimes => new Runtimes());
 
 $container->set(
     'runtimes',
-    new Dependency([], fn (): Runtimes => $registry->get('runtimes'))
+    fn (): Runtimes => $registry->get('runtimes'),
+    []
 );
 
 $container->set(
     'orchestration',
-    new Dependency([], fn (): Orchestration => new Orchestration(new DockerAPI(
+    fn (): Orchestration => new Orchestration(new DockerAPI(
         System::getEnv('OPR_EXECUTOR_DOCKER_HUB_USERNAME', ''),
         System::getEnv('OPR_EXECUTOR_DOCKER_HUB_PASSWORD', '')
-    )))
+    )),
+    []
 );
 
 $container->set(
     'network',
-    new Dependency(
-        ['orchestration'],
-        fn (Orchestration $orchestration): Network => new Network($orchestration)
-    )
+    fn (Orchestration $orchestration): Network => new Network($orchestration),
+    ['orchestration']
 );
 
 $container->set(
     'imagePuller',
-    new Dependency(
-        ['orchestration'],
-        fn (Orchestration $orchestration): ImagePuller => new ImagePuller($orchestration)
-    )
+    fn (Orchestration $orchestration): ImagePuller => new ImagePuller($orchestration),
+    ['orchestration']
 );
 
 $container->set(
     'maintenance',
-    new Dependency(
-        ['orchestration', 'runtimes'],
-        fn (Orchestration $orchestration, Runtimes $runtimes): Maintenance => new Maintenance($orchestration, $runtimes)
-    )
+    fn (Orchestration $orchestration, Runtimes $runtimes): Maintenance => new Maintenance($orchestration, $runtimes),
+    ['orchestration', 'runtimes']
 );
 
 $container->set(
     'runner',
-    new Dependency(
-        ['orchestration', 'runtimes', 'networks'],
-        fn (Orchestration $orchestration, Runtimes $runtimes, array $networks): Adapter => new Docker($orchestration, $runtimes, $networks)
-    )
+    fn (Orchestration $orchestration, Runtimes $runtimes, array $networks): Adapter => new Docker($orchestration, $runtimes, $networks),
+    ['orchestration', 'runtimes', 'networks']
 );

--- a/app/init.php
+++ b/app/init.php
@@ -6,7 +6,7 @@ use OpenRuntimes\Executor\Runner\Maintenance;
 use OpenRuntimes\Executor\Runner\Network;
 use OpenRuntimes\Executor\Runner\Repository\Runtimes;
 use OpenRuntimes\Executor\Runner\Adapter;
-use Utopia\Http\Http;
+use Utopia\DI\Container;
 use Utopia\Orchestration\Adapter\DockerAPI;
 use Utopia\Orchestration\Orchestration;
 use Utopia\System\System;
@@ -18,21 +18,22 @@ const MAX_BUILD_LOG_SIZE = 1000 * 1000;
 
 Config::load('errors', __DIR__ . '/config/errors.php');
 
+$container = new Container();
 $registry = new Registry();
 
 $registry->set('runtimes', fn (): \OpenRuntimes\Executor\Runner\Repository\Runtimes => new Runtimes());
 
-Http::setResource('runtimes', fn () => $registry->get('runtimes'));
+$container->setResource('runtimes', fn () => $registry->get('runtimes'));
 
-Http::setResource('orchestration', fn (): Orchestration => new Orchestration(new DockerAPI(
+$container->setResource('orchestration', fn (): Orchestration => new Orchestration(new DockerAPI(
     System::getEnv('OPR_EXECUTOR_DOCKER_HUB_USERNAME', ''),
     System::getEnv('OPR_EXECUTOR_DOCKER_HUB_PASSWORD', '')
 )));
 
-Http::setResource('network', fn (Orchestration $orchestration): Network => new Network($orchestration), ['orchestration']);
+$container->setResource('network', fn (Orchestration $orchestration): Network => new Network($orchestration), ['orchestration']);
 
-Http::setResource('imagePuller', fn (Orchestration $orchestration): ImagePuller => new ImagePuller($orchestration), ['orchestration']);
+$container->setResource('imagePuller', fn (Orchestration $orchestration): ImagePuller => new ImagePuller($orchestration), ['orchestration']);
 
-Http::setResource('maintenance', fn (Orchestration $orchestration, Runtimes $runtimes): Maintenance => new Maintenance($orchestration, $runtimes), ['orchestration', 'runtimes']);
+$container->setResource('maintenance', fn (Orchestration $orchestration, Runtimes $runtimes): Maintenance => new Maintenance($orchestration, $runtimes), ['orchestration', 'runtimes']);
 
-Http::setResource('runner', fn (Orchestration $orchestration, Runtimes $runtimes, array $networks): Adapter => new Docker($orchestration, $runtimes, $networks), ['orchestration', 'runtimes', 'networks']);
+$container->setResource('runner', fn (Orchestration $orchestration, Runtimes $runtimes, array $networks): Adapter => new Docker($orchestration, $runtimes, $networks), ['orchestration', 'runtimes', 'networks']);

--- a/app/init.php
+++ b/app/init.php
@@ -22,19 +22,49 @@ Config::load('errors', __DIR__ . '/config/errors.php');
 $container = new Container();
 $registry = new Registry();
 
-$registry->set('runtimes', fn (): \OpenRuntimes\Executor\Runner\Repository\Runtimes => new Runtimes());
+$registry->set('runtimes', fn (): Runtimes => new Runtimes());
 
-$container->set('runtimes', new Dependency([], fn (): Runtimes => $registry->get('runtimes')));
+$container->set(
+    'runtimes',
+    new Dependency([], fn (): Runtimes => $registry->get('runtimes'))
+);
 
-$container->set('orchestration', new Dependency([], fn (): Orchestration => new Orchestration(new DockerAPI(
-    System::getEnv('OPR_EXECUTOR_DOCKER_HUB_USERNAME', ''),
-    System::getEnv('OPR_EXECUTOR_DOCKER_HUB_PASSWORD', '')
-))));
+$container->set(
+    'orchestration',
+    new Dependency([], fn (): Orchestration => new Orchestration(new DockerAPI(
+        System::getEnv('OPR_EXECUTOR_DOCKER_HUB_USERNAME', ''),
+        System::getEnv('OPR_EXECUTOR_DOCKER_HUB_PASSWORD', '')
+    )))
+);
 
-$container->set('network', new Dependency(['orchestration'], fn (Orchestration $orchestration): Network => new Network($orchestration)));
+$container->set(
+    'network',
+    new Dependency(
+        ['orchestration'],
+        fn (Orchestration $orchestration): Network => new Network($orchestration)
+    )
+);
 
-$container->set('imagePuller', new Dependency(['orchestration'], fn (Orchestration $orchestration): ImagePuller => new ImagePuller($orchestration)));
+$container->set(
+    'imagePuller',
+    new Dependency(
+        ['orchestration'],
+        fn (Orchestration $orchestration): ImagePuller => new ImagePuller($orchestration)
+    )
+);
 
-$container->set('maintenance', new Dependency(['orchestration', 'runtimes'], fn (Orchestration $orchestration, Runtimes $runtimes): Maintenance => new Maintenance($orchestration, $runtimes)));
+$container->set(
+    'maintenance',
+    new Dependency(
+        ['orchestration', 'runtimes'],
+        fn (Orchestration $orchestration, Runtimes $runtimes): Maintenance => new Maintenance($orchestration, $runtimes)
+    )
+);
 
-$container->set('runner', new Dependency(['orchestration', 'runtimes', 'networks'], fn (Orchestration $orchestration, Runtimes $runtimes, array $networks): Adapter => new Docker($orchestration, $runtimes, $networks)));
+$container->set(
+    'runner',
+    new Dependency(
+        ['orchestration', 'runtimes', 'networks'],
+        fn (Orchestration $orchestration, Runtimes $runtimes, array $networks): Adapter => new Docker($orchestration, $runtimes, $networks)
+    )
+);

--- a/app/init.php
+++ b/app/init.php
@@ -7,6 +7,7 @@ use OpenRuntimes\Executor\Runner\Network;
 use OpenRuntimes\Executor\Runner\Repository\Runtimes;
 use OpenRuntimes\Executor\Runner\Adapter;
 use Utopia\DI\Container;
+use Utopia\DI\Dependency;
 use Utopia\Orchestration\Adapter\DockerAPI;
 use Utopia\Orchestration\Orchestration;
 use Utopia\System\System;
@@ -23,17 +24,17 @@ $registry = new Registry();
 
 $registry->set('runtimes', fn (): \OpenRuntimes\Executor\Runner\Repository\Runtimes => new Runtimes());
 
-$container->setResource('runtimes', fn () => $registry->get('runtimes'));
+$container->set('runtimes', new Dependency([], fn (): Runtimes => $registry->get('runtimes')));
 
-$container->setResource('orchestration', fn (): Orchestration => new Orchestration(new DockerAPI(
+$container->set('orchestration', new Dependency([], fn (): Orchestration => new Orchestration(new DockerAPI(
     System::getEnv('OPR_EXECUTOR_DOCKER_HUB_USERNAME', ''),
     System::getEnv('OPR_EXECUTOR_DOCKER_HUB_PASSWORD', '')
-)));
+))));
 
-$container->setResource('network', fn (Orchestration $orchestration): Network => new Network($orchestration), ['orchestration']);
+$container->set('network', new Dependency(['orchestration'], fn (Orchestration $orchestration): Network => new Network($orchestration)));
 
-$container->setResource('imagePuller', fn (Orchestration $orchestration): ImagePuller => new ImagePuller($orchestration), ['orchestration']);
+$container->set('imagePuller', new Dependency(['orchestration'], fn (Orchestration $orchestration): ImagePuller => new ImagePuller($orchestration)));
 
-$container->setResource('maintenance', fn (Orchestration $orchestration, Runtimes $runtimes): Maintenance => new Maintenance($orchestration, $runtimes), ['orchestration', 'runtimes']);
+$container->set('maintenance', new Dependency(['orchestration', 'runtimes'], fn (Orchestration $orchestration, Runtimes $runtimes): Maintenance => new Maintenance($orchestration, $runtimes)));
 
-$container->setResource('runner', fn (Orchestration $orchestration, Runtimes $runtimes, array $networks): Adapter => new Docker($orchestration, $runtimes, $networks), ['orchestration', 'runtimes', 'networks']);
+$container->set('runner', new Dependency(['orchestration', 'runtimes', 'networks'], fn (Orchestration $orchestration, Runtimes $runtimes, array $networks): Adapter => new Docker($orchestration, $runtimes, $networks)));

--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,10 @@
     "ext-swoole": "*",
     "utopia-php/config": "^0.2.2",
     "utopia-php/console": "0.0.*",
+    "utopia-php/di": "dev-chore/extract-http-di-resources as 0.1.0",
     "utopia-php/dsn": "0.2.*",
     "utopia-php/fetch": "0.4.*",
-    "utopia-php/framework": "0.34.*",
+    "utopia-php/framework": "dev-feat/use-di-resource-container as 0.34.14",
     "utopia-php/orchestration": "0.19.*",
     "utopia-php/preloader": "0.2.*",
     "utopia-php/registry": "0.5.*",
@@ -42,6 +43,16 @@
     "rector/rector": "2.3.8",
     "swoole/ide-helper": "5.1.2"
   },
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/utopia-php/http"
+    },
+    {
+      "type": "vcs",
+      "url": "https://github.com/utopia-php/di"
+    }
+  ],
   "config": {
     "platform": {
       "php": "8.3"

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "utopia-php/di": "0.3.*",
     "utopia-php/dsn": "0.2.*",
     "utopia-php/fetch": "0.4.*",
-    "utopia-php/framework": "dev-feat/use-di-resource-container as 0.34.14",
+    "utopia-php/framework": "0.34.*",
     "utopia-php/orchestration": "0.19.*",
     "utopia-php/preloader": "0.2.*",
     "utopia-php/registry": "0.5.*",
@@ -43,16 +43,6 @@
     "rector/rector": "2.3.8",
     "swoole/ide-helper": "5.1.2"
   },
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/utopia-php/http"
-    },
-    {
-      "type": "vcs",
-      "url": "https://github.com/utopia-php/di"
-    }
-  ],
   "config": {
     "platform": {
       "php": "8.3"

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "ext-swoole": "*",
     "utopia-php/config": "^0.2.2",
     "utopia-php/console": "0.0.*",
-    "utopia-php/di": "dev-chore/extract-http-di-resources as 0.1.0",
+    "utopia-php/di": "0.2.*",
     "utopia-php/dsn": "0.2.*",
     "utopia-php/fetch": "0.4.*",
     "utopia-php/framework": "dev-feat/use-di-resource-container as 0.34.14",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "ext-swoole": "*",
     "utopia-php/config": "^0.2.2",
     "utopia-php/console": "0.0.*",
-    "utopia-php/di": "0.2.*",
+    "utopia-php/di": "0.3.*",
     "utopia-php/dsn": "0.2.*",
     "utopia-php/fetch": "0.4.*",
     "utopia-php/framework": "dev-feat/use-di-resource-container as 0.34.14",

--- a/composer.lock
+++ b/composer.lock
@@ -2133,12 +2133,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/http.git",
-                "reference": "b872c6b88bc6fdce5eea1908a6d9eecb21d10ec5"
+                "reference": "f119f26e62bc260df7d00e956fbac9add199b22b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/http/zipball/b872c6b88bc6fdce5eea1908a6d9eecb21d10ec5",
-                "reference": "b872c6b88bc6fdce5eea1908a6d9eecb21d10ec5",
+                "url": "https://api.github.com/repos/utopia-php/http/zipball/f119f26e62bc260df7d00e956fbac9add199b22b",
+                "reference": "f119f26e62bc260df7d00e956fbac9add199b22b",
                 "shasum": ""
             },
             "require": {
@@ -2177,7 +2177,7 @@
                 "issues": "https://github.com/utopia-php/http/issues",
                 "source": "https://github.com/utopia-php/http/tree/feat/use-di-resource-container"
             },
-            "time": "2026-03-13T05:51:10+00:00"
+            "time": "2026-03-13T11:03:30+00:00"
         },
         {
             "name": "utopia-php/orchestration",

--- a/composer.lock
+++ b/composer.lock
@@ -1972,12 +1972,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/di.git",
-                "reference": "0c7671d69ba95d3f7801d4a993ec6b6c78a4cf9b"
+                "reference": "3d8a454963a1db81cd63bc4f0f74c1488716e6b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/di/zipball/0c7671d69ba95d3f7801d4a993ec6b6c78a4cf9b",
-                "reference": "0c7671d69ba95d3f7801d4a993ec6b6c78a4cf9b",
+                "url": "https://api.github.com/repos/utopia-php/di/zipball/3d8a454963a1db81cd63bc4f0f74c1488716e6b8",
+                "reference": "3d8a454963a1db81cd63bc4f0f74c1488716e6b8",
                 "shasum": ""
             },
             "require": {
@@ -2025,7 +2025,7 @@
                 "source": "https://github.com/utopia-php/di/tree/chore/extract-http-di-resources",
                 "issues": "https://github.com/utopia-php/di/issues"
             },
-            "time": "2026-03-10T07:15:52+00:00"
+            "time": "2026-03-11T10:23:32+00:00"
         },
         {
             "name": "utopia-php/dsn",
@@ -2119,12 +2119,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/http.git",
-                "reference": "bf94cd26e7cd76ad0b5b6ef83efbc8ca41795164"
+                "reference": "82d74810b34f3b6faa82071c06068edd4e70b4e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/http/zipball/bf94cd26e7cd76ad0b5b6ef83efbc8ca41795164",
-                "reference": "bf94cd26e7cd76ad0b5b6ef83efbc8ca41795164",
+                "url": "https://api.github.com/repos/utopia-php/http/zipball/82d74810b34f3b6faa82071c06068edd4e70b4e9",
+                "reference": "82d74810b34f3b6faa82071c06068edd4e70b4e9",
                 "shasum": ""
             },
             "require": {
@@ -2162,7 +2162,7 @@
                 "issues": "https://github.com/utopia-php/http/issues",
                 "source": "https://github.com/utopia-php/http/tree/feat/use-di-resource-container"
             },
-            "time": "2026-03-10T06:20:15+00:00"
+            "time": "2026-03-11T10:24:11+00:00"
         },
         {
             "name": "utopia-php/orchestration",

--- a/composer.lock
+++ b/composer.lock
@@ -1968,16 +1968,16 @@
         },
         {
             "name": "utopia-php/di",
-            "version": "0.3.0",
+            "version": "0.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/di.git",
-                "reference": "72e1a3e67c58f8f03cf3faa5d79ee814136d3fe2"
+                "reference": "68873b7267842315d01d82a83b988bae525eab31"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/di/zipball/72e1a3e67c58f8f03cf3faa5d79ee814136d3fe2",
-                "reference": "72e1a3e67c58f8f03cf3faa5d79ee814136d3fe2",
+                "url": "https://api.github.com/repos/utopia-php/di/zipball/68873b7267842315d01d82a83b988bae525eab31",
+                "reference": "68873b7267842315d01d82a83b988bae525eab31",
                 "shasum": ""
             },
             "require": {
@@ -2036,10 +2036,10 @@
                 "utopia"
             ],
             "support": {
-                "source": "https://github.com/utopia-php/di/tree/0.3.0",
+                "source": "https://github.com/utopia-php/di/tree/0.3.1",
                 "issues": "https://github.com/utopia-php/di/issues"
             },
-            "time": "2026-03-12T10:40:23+00:00"
+            "time": "2026-03-13T05:47:23+00:00"
         },
         {
             "name": "utopia-php/dsn",
@@ -2133,12 +2133,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/http.git",
-                "reference": "664436bcc95b0bb328b75577ceaf8bb9a1c6794b"
+                "reference": "b872c6b88bc6fdce5eea1908a6d9eecb21d10ec5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/http/zipball/664436bcc95b0bb328b75577ceaf8bb9a1c6794b",
-                "reference": "664436bcc95b0bb328b75577ceaf8bb9a1c6794b",
+                "url": "https://api.github.com/repos/utopia-php/http/zipball/b872c6b88bc6fdce5eea1908a6d9eecb21d10ec5",
+                "reference": "b872c6b88bc6fdce5eea1908a6d9eecb21d10ec5",
                 "shasum": ""
             },
             "require": {
@@ -2177,7 +2177,7 @@
                 "issues": "https://github.com/utopia-php/http/issues",
                 "source": "https://github.com/utopia-php/http/tree/feat/use-di-resource-container"
             },
-            "time": "2026-03-13T04:51:55+00:00"
+            "time": "2026-03-13T05:51:10+00:00"
         },
         {
             "name": "utopia-php/orchestration",

--- a/composer.lock
+++ b/composer.lock
@@ -1972,16 +1972,17 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/di.git",
-                "reference": "3d8a454963a1db81cd63bc4f0f74c1488716e6b8"
+                "reference": "f4bbf60d05edb2342ea09d44e90573180c212ec7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/di/zipball/3d8a454963a1db81cd63bc4f0f74c1488716e6b8",
-                "reference": "3d8a454963a1db81cd63bc4f0f74c1488716e6b8",
+                "url": "https://api.github.com/repos/utopia-php/di/zipball/f4bbf60d05edb2342ea09d44e90573180c212ec7",
+                "reference": "f4bbf60d05edb2342ea09d44e90573180c212ec7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.2",
+                "psr/container": "^2.0"
             },
             "require-dev": {
                 "laravel/pint": "^1.27",
@@ -2005,7 +2006,18 @@
                     "vendor/bin/pint --test"
                 ],
                 "analyze": [
-                    "vendor/bin/phpstan analyse -c phpstan.neon"
+                    "vendor/bin/phpstan analyse --memory-limit=512M"
+                ],
+                "refactor": [
+                    "tools/rector/vendor/bin/rector process --config=rector.php"
+                ],
+                "refactor:check": [
+                    "tools/rector/vendor/bin/rector process --dry-run --config=rector.php"
+                ],
+                "fix": [
+                    "@refactor",
+                    "@analyze",
+                    "@format"
                 ],
                 "test": [
                     "vendor/bin/phpunit --configuration phpunit.xml"
@@ -2016,16 +2028,18 @@
             ],
             "description": "A simple and lite library for managing dependency injections",
             "keywords": [
-                "framework",
-                "http",
+                "container",
+                "dependency-injection",
+                "di",
                 "php",
+                "psr-11",
                 "utopia"
             ],
             "support": {
                 "source": "https://github.com/utopia-php/di/tree/chore/extract-http-di-resources",
                 "issues": "https://github.com/utopia-php/di/issues"
             },
-            "time": "2026-03-11T10:23:32+00:00"
+            "time": "2026-03-12T05:13:45+00:00"
         },
         {
             "name": "utopia-php/dsn",
@@ -2119,12 +2133,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/http.git",
-                "reference": "82d74810b34f3b6faa82071c06068edd4e70b4e9"
+                "reference": "5bc45e3cbc41d5bf8d475aa8109b8c48a9da4996"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/http/zipball/82d74810b34f3b6faa82071c06068edd4e70b4e9",
-                "reference": "82d74810b34f3b6faa82071c06068edd4e70b4e9",
+                "url": "https://api.github.com/repos/utopia-php/http/zipball/5bc45e3cbc41d5bf8d475aa8109b8c48a9da4996",
+                "reference": "5bc45e3cbc41d5bf8d475aa8109b8c48a9da4996",
                 "shasum": ""
             },
             "require": {
@@ -2134,6 +2148,7 @@
                 "utopia-php/validators": "0.2.*"
             },
             "require-dev": {
+                "doctrine/instantiator": "^1.5",
                 "laravel/pint": "1.*",
                 "phpbench/phpbench": "^1.2",
                 "phpstan/phpstan": "1.*",
@@ -2162,7 +2177,7 @@
                 "issues": "https://github.com/utopia-php/http/issues",
                 "source": "https://github.com/utopia-php/http/tree/feat/use-di-resource-container"
             },
-            "time": "2026-03-11T10:24:11+00:00"
+            "time": "2026-03-12T06:04:20+00:00"
         },
         {
             "name": "utopia-php/orchestration",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e18bdec90d703c20173a98f4a3949f88",
+    "content-hash": "d1cd8cd301f7c5cb03e480173b072197",
     "packages": [
         {
             "name": "brick/math",
@@ -1306,16 +1306,16 @@
         },
         {
             "name": "symfony/http-client",
-            "version": "v7.4.6",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "2bde8afd5ab2fe0b05a9c2d4c3c0e28ceb98a154"
+                "reference": "1010624285470eb60e88ed10035102c75b4ea6af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/2bde8afd5ab2fe0b05a9c2d4c3c0e28ceb98a154",
-                "reference": "2bde8afd5ab2fe0b05a9c2d4c3c0e28ceb98a154",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/1010624285470eb60e88ed10035102c75b4ea6af",
+                "reference": "1010624285470eb60e88ed10035102c75b4ea6af",
                 "shasum": ""
             },
             "require": {
@@ -1383,7 +1383,7 @@
                 "http"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client/tree/v7.4.6"
+                "source": "https://github.com/symfony/http-client/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -1403,7 +1403,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-18T09:46:18+00:00"
+            "time": "2026-03-05T11:16:58+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
@@ -1967,6 +1967,67 @@
             "time": "2025-10-20T14:41:36+00:00"
         },
         {
+            "name": "utopia-php/di",
+            "version": "dev-chore/extract-http-di-resources",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/utopia-php/di.git",
+                "reference": "0c7671d69ba95d3f7801d4a993ec6b6c78a4cf9b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/utopia-php/di/zipball/0c7671d69ba95d3f7801d4a993ec6b6c78a4cf9b",
+                "reference": "0c7671d69ba95d3f7801d4a993ec6b6c78a4cf9b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.27",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^9.5.25",
+                "swoole/ide-helper": "4.8.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Utopia\\": "src/",
+                    "Tests\\E2E\\": "tests/e2e"
+                }
+            },
+            "scripts": {
+                "format": [
+                    "vendor/bin/pint"
+                ],
+                "format:check": [
+                    "vendor/bin/pint --test"
+                ],
+                "analyze": [
+                    "vendor/bin/phpstan analyse -c phpstan.neon"
+                ],
+                "test": [
+                    "vendor/bin/phpunit --configuration phpunit.xml"
+                ]
+            },
+            "license": [
+                "MIT"
+            ],
+            "description": "A simple and lite library for managing dependency injections",
+            "keywords": [
+                "framework",
+                "http",
+                "php",
+                "utopia"
+            ],
+            "support": {
+                "source": "https://github.com/utopia-php/di/tree/chore/extract-http-di-resources",
+                "issues": "https://github.com/utopia-php/di/issues"
+            },
+            "time": "2026-03-10T07:15:52+00:00"
+        },
+        {
             "name": "utopia-php/dsn",
             "version": "0.2.1",
             "source": {
@@ -2054,21 +2115,22 @@
         },
         {
             "name": "utopia-php/framework",
-            "version": "0.34.14",
+            "version": "dev-feat/use-di-resource-container",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/http.git",
-                "reference": "d60c9ce7eea3e4f89599d995e0058e3729a1ef7c"
+                "reference": "bf94cd26e7cd76ad0b5b6ef83efbc8ca41795164"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/http/zipball/d60c9ce7eea3e4f89599d995e0058e3729a1ef7c",
-                "reference": "d60c9ce7eea3e4f89599d995e0058e3729a1ef7c",
+                "url": "https://api.github.com/repos/utopia-php/http/zipball/bf94cd26e7cd76ad0b5b6ef83efbc8ca41795164",
+                "reference": "bf94cd26e7cd76ad0b5b6ef83efbc8ca41795164",
                 "shasum": ""
             },
             "require": {
                 "ext-swoole": "*",
-                "php": ">=8.0",
+                "php": ">=8.2",
+                "utopia-php/di": "dev-chore/extract-http-di-resources",
                 "utopia-php/validators": "0.2.*"
             },
             "require-dev": {
@@ -2098,9 +2160,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/http/issues",
-                "source": "https://github.com/utopia-php/http/tree/0.34.14"
+                "source": "https://github.com/utopia-php/http/tree/feat/use-di-resource-container"
             },
-            "time": "2026-02-25T17:31:12+00:00"
+            "time": "2026-03-10T06:20:15+00:00"
         },
         {
             "name": "utopia-php/orchestration",
@@ -2538,16 +2600,16 @@
         },
         {
             "name": "laravel/pint",
-            "version": "v1.27.1",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "54cca2de13790570c7b6f0f94f37896bee4abcb5"
+                "reference": "1feae84bf9c1649d99ba8f7b8193bf0f09f04cc9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/54cca2de13790570c7b6f0f94f37896bee4abcb5",
-                "reference": "54cca2de13790570c7b6f0f94f37896bee4abcb5",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/1feae84bf9c1649d99ba8f7b8193bf0f09f04cc9",
+                "reference": "1feae84bf9c1649d99ba8f7b8193bf0f09f04cc9",
                 "shasum": ""
             },
             "require": {
@@ -2558,13 +2620,14 @@
                 "php": "^8.2.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.93.1",
-                "illuminate/view": "^12.51.0",
-                "larastan/larastan": "^3.9.2",
+                "friendsofphp/php-cs-fixer": "^3.94.2",
+                "illuminate/view": "^12.54.1",
+                "larastan/larastan": "^3.9.3",
                 "laravel-zero/framework": "^12.0.5",
                 "mockery/mockery": "^1.6.12",
-                "nunomaduro/termwind": "^2.3.3",
-                "pestphp/pest": "^3.8.5"
+                "nunomaduro/termwind": "^2.4.0",
+                "pestphp/pest": "^3.8.5",
+                "shipfastlabs/agent-detector": "^1.0.2"
             },
             "bin": [
                 "builds/pint"
@@ -2601,7 +2664,7 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2026-02-10T20:00:20+00:00"
+            "time": "2026-03-10T20:37:18+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -4476,9 +4539,25 @@
             "time": "2025-11-17T20:03:58+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "utopia-php/di",
+            "version": "dev-chore/extract-http-di-resources",
+            "alias": "0.1.0",
+            "alias_normalized": "0.1.0.0"
+        },
+        {
+            "package": "utopia-php/framework",
+            "version": "dev-feat/use-di-resource-container",
+            "alias": "0.34.14",
+            "alias_normalized": "0.34.14.0"
+        }
+    ],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": {
+        "utopia-php/di": 20,
+        "utopia-php/framework": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bc9a82b0e8c02b8032096952e784d0cc",
+    "content-hash": "eec8a060ed25b31008c39b47ef9c991d",
     "packages": [
         {
             "name": "brick/math",
@@ -2129,16 +2129,16 @@
         },
         {
             "name": "utopia-php/framework",
-            "version": "dev-feat/use-di-resource-container",
+            "version": "0.34.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/http.git",
-                "reference": "f119f26e62bc260df7d00e956fbac9add199b22b"
+                "reference": "15d1195fc26cd542b1a5a7e5eb00a042bc7cf350"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/http/zipball/f119f26e62bc260df7d00e956fbac9add199b22b",
-                "reference": "f119f26e62bc260df7d00e956fbac9add199b22b",
+                "url": "https://api.github.com/repos/utopia-php/http/zipball/15d1195fc26cd542b1a5a7e5eb00a042bc7cf350",
+                "reference": "15d1195fc26cd542b1a5a7e5eb00a042bc7cf350",
                 "shasum": ""
             },
             "require": {
@@ -2175,9 +2175,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/http/issues",
-                "source": "https://github.com/utopia-php/http/tree/feat/use-di-resource-container"
+                "source": "https://github.com/utopia-php/http/tree/0.34.15"
             },
-            "time": "2026-03-13T11:03:30+00:00"
+            "time": "2026-03-13T11:28:26+00:00"
         },
         {
             "name": "utopia-php/orchestration",
@@ -4554,18 +4554,9 @@
             "time": "2025-11-17T20:03:58+00:00"
         }
     ],
-    "aliases": [
-        {
-            "package": "utopia-php/framework",
-            "version": "dev-feat/use-di-resource-container",
-            "alias": "0.34.14",
-            "alias_normalized": "0.34.14.0"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "utopia-php/framework": 20
-    },
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d1cd8cd301f7c5cb03e480173b072197",
+    "content-hash": "216a6e5347fd1c051e43110d70589381",
     "packages": [
         {
             "name": "brick/math",
@@ -1968,16 +1968,16 @@
         },
         {
             "name": "utopia-php/di",
-            "version": "dev-chore/extract-http-di-resources",
+            "version": "0.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/di.git",
-                "reference": "f4bbf60d05edb2342ea09d44e90573180c212ec7"
+                "reference": "6a9135908dddef66fd07733705b9625f42d302a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/di/zipball/f4bbf60d05edb2342ea09d44e90573180c212ec7",
-                "reference": "f4bbf60d05edb2342ea09d44e90573180c212ec7",
+                "url": "https://api.github.com/repos/utopia-php/di/zipball/6a9135908dddef66fd07733705b9625f42d302a4",
+                "reference": "6a9135908dddef66fd07733705b9625f42d302a4",
                 "shasum": ""
             },
             "require": {
@@ -2036,10 +2036,10 @@
                 "utopia"
             ],
             "support": {
-                "source": "https://github.com/utopia-php/di/tree/chore/extract-http-di-resources",
+                "source": "https://github.com/utopia-php/di/tree/0.2.0",
                 "issues": "https://github.com/utopia-php/di/issues"
             },
-            "time": "2026-03-12T05:13:45+00:00"
+            "time": "2026-03-12T07:54:46+00:00"
         },
         {
             "name": "utopia-php/dsn",
@@ -2133,18 +2133,18 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/http.git",
-                "reference": "5bc45e3cbc41d5bf8d475aa8109b8c48a9da4996"
+                "reference": "9616993cb942a87d7b3cee58d0780cb63406115e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/http/zipball/5bc45e3cbc41d5bf8d475aa8109b8c48a9da4996",
-                "reference": "5bc45e3cbc41d5bf8d475aa8109b8c48a9da4996",
+                "url": "https://api.github.com/repos/utopia-php/http/zipball/9616993cb942a87d7b3cee58d0780cb63406115e",
+                "reference": "9616993cb942a87d7b3cee58d0780cb63406115e",
                 "shasum": ""
             },
             "require": {
                 "ext-swoole": "*",
                 "php": ">=8.2",
-                "utopia-php/di": "dev-chore/extract-http-di-resources",
+                "utopia-php/di": "0.2.*",
                 "utopia-php/validators": "0.2.*"
             },
             "require-dev": {
@@ -2177,7 +2177,7 @@
                 "issues": "https://github.com/utopia-php/http/issues",
                 "source": "https://github.com/utopia-php/http/tree/feat/use-di-resource-container"
             },
-            "time": "2026-03-12T06:04:20+00:00"
+            "time": "2026-03-12T08:36:48+00:00"
         },
         {
             "name": "utopia-php/orchestration",
@@ -4556,12 +4556,6 @@
     ],
     "aliases": [
         {
-            "package": "utopia-php/di",
-            "version": "dev-chore/extract-http-di-resources",
-            "alias": "0.1.0",
-            "alias_normalized": "0.1.0.0"
-        },
-        {
             "package": "utopia-php/framework",
             "version": "dev-feat/use-di-resource-container",
             "alias": "0.34.14",
@@ -4570,7 +4564,6 @@
     ],
     "minimum-stability": "stable",
     "stability-flags": {
-        "utopia-php/di": 20,
         "utopia-php/framework": 20
     },
     "prefer-stable": false,

--- a/composer.lock
+++ b/composer.lock
@@ -2133,12 +2133,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/http.git",
-                "reference": "6225de47970f5cd8835ff9406f1cc656b3955624"
+                "reference": "664436bcc95b0bb328b75577ceaf8bb9a1c6794b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/http/zipball/6225de47970f5cd8835ff9406f1cc656b3955624",
-                "reference": "6225de47970f5cd8835ff9406f1cc656b3955624",
+                "url": "https://api.github.com/repos/utopia-php/http/zipball/664436bcc95b0bb328b75577ceaf8bb9a1c6794b",
+                "reference": "664436bcc95b0bb328b75577ceaf8bb9a1c6794b",
                 "shasum": ""
             },
             "require": {
@@ -2177,7 +2177,7 @@
                 "issues": "https://github.com/utopia-php/http/issues",
                 "source": "https://github.com/utopia-php/http/tree/feat/use-di-resource-container"
             },
-            "time": "2026-03-12T11:35:56+00:00"
+            "time": "2026-03-13T04:51:55+00:00"
         },
         {
             "name": "utopia-php/orchestration",
@@ -2615,16 +2615,16 @@
         },
         {
             "name": "laravel/pint",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "1feae84bf9c1649d99ba8f7b8193bf0f09f04cc9"
+                "reference": "bdec963f53172c5e36330f3a400604c69bf02d39"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/1feae84bf9c1649d99ba8f7b8193bf0f09f04cc9",
-                "reference": "1feae84bf9c1649d99ba8f7b8193bf0f09f04cc9",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/bdec963f53172c5e36330f3a400604c69bf02d39",
+                "reference": "bdec963f53172c5e36330f3a400604c69bf02d39",
                 "shasum": ""
             },
             "require": {
@@ -2641,8 +2641,8 @@
                 "laravel-zero/framework": "^12.0.5",
                 "mockery/mockery": "^1.6.12",
                 "nunomaduro/termwind": "^2.4.0",
-                "pestphp/pest": "^3.8.5",
-                "shipfastlabs/agent-detector": "^1.0.2"
+                "pestphp/pest": "^3.8.6",
+                "shipfastlabs/agent-detector": "^1.1.0"
             },
             "bin": [
                 "builds/pint"
@@ -2679,7 +2679,7 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2026-03-10T20:37:18+00:00"
+            "time": "2026-03-12T15:51:39+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "216a6e5347fd1c051e43110d70589381",
+    "content-hash": "bc9a82b0e8c02b8032096952e784d0cc",
     "packages": [
         {
             "name": "brick/math",
@@ -1968,16 +1968,16 @@
         },
         {
             "name": "utopia-php/di",
-            "version": "0.2.0",
+            "version": "0.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/di.git",
-                "reference": "6a9135908dddef66fd07733705b9625f42d302a4"
+                "reference": "72e1a3e67c58f8f03cf3faa5d79ee814136d3fe2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/di/zipball/6a9135908dddef66fd07733705b9625f42d302a4",
-                "reference": "6a9135908dddef66fd07733705b9625f42d302a4",
+                "url": "https://api.github.com/repos/utopia-php/di/zipball/72e1a3e67c58f8f03cf3faa5d79ee814136d3fe2",
+                "reference": "72e1a3e67c58f8f03cf3faa5d79ee814136d3fe2",
                 "shasum": ""
             },
             "require": {
@@ -2036,10 +2036,10 @@
                 "utopia"
             ],
             "support": {
-                "source": "https://github.com/utopia-php/di/tree/0.2.0",
+                "source": "https://github.com/utopia-php/di/tree/0.3.0",
                 "issues": "https://github.com/utopia-php/di/issues"
             },
-            "time": "2026-03-12T07:54:46+00:00"
+            "time": "2026-03-12T10:40:23+00:00"
         },
         {
             "name": "utopia-php/dsn",
@@ -2133,18 +2133,18 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/http.git",
-                "reference": "9616993cb942a87d7b3cee58d0780cb63406115e"
+                "reference": "6225de47970f5cd8835ff9406f1cc656b3955624"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/http/zipball/9616993cb942a87d7b3cee58d0780cb63406115e",
-                "reference": "9616993cb942a87d7b3cee58d0780cb63406115e",
+                "url": "https://api.github.com/repos/utopia-php/http/zipball/6225de47970f5cd8835ff9406f1cc656b3955624",
+                "reference": "6225de47970f5cd8835ff9406f1cc656b3955624",
                 "shasum": ""
             },
             "require": {
                 "ext-swoole": "*",
                 "php": ">=8.2",
-                "utopia-php/di": "0.2.*",
+                "utopia-php/di": "0.3.*",
                 "utopia-php/validators": "0.2.*"
             },
             "require-dev": {
@@ -2177,7 +2177,7 @@
                 "issues": "https://github.com/utopia-php/http/issues",
                 "source": "https://github.com/utopia-php/http/tree/feat/use-di-resource-container"
             },
-            "time": "2026-03-12T08:36:48+00:00"
+            "time": "2026-03-12T11:35:56+00:00"
         },
         {
             "name": "utopia-php/orchestration",

--- a/tests/e2e/ExecutorTest.php
+++ b/tests/e2e/ExecutorTest.php
@@ -222,8 +222,8 @@ class ExecutorTest extends TestCase
 
         /** Ensure build folder cleanup */
         $tmpFolderPath = '/tmp/executor-test-build-' . $runtimeId;
-        $this->assertDirectoryNotExists($tmpFolderPath);
-        $this->assertFileNotExists($tmpFolderPath);
+        $this->assertDirectoryDoesNotExist($tmpFolderPath);
+        $this->assertFileDoesNotExist($tmpFolderPath);
 
         /** List runtimes */
         $response = $this->client->call(Client::METHOD_GET, '/runtimes', [], []);


### PR DESCRIPTION
## Summary
- switch executor bootstrap resource registration from `Http::setResource()` to a shared `Utopia\DI\Container`
- pass the DI container into `Http` so framework-owned runtime resources stay in the HTTP layer
- point Composer at the `utopia-php/framework` and `utopia-php/di` development branches required for this integration

## Notes
- `composer.lock` now resolves `utopia-php/framework` from `feat/use-di-resource-container`
- `composer.lock` now resolves `utopia-php/di` from `chore/extract-http-di-resources`
- the lockfile also includes a few upstream package bumps from the Composer update

## Verification
- `php -l app/init.php`
- `php -l app/http.php`