### PR TITLE
Use renamed Utopia HTTP package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "utopia-php/console": "^0.1.1",
     "utopia-php/di": "0.3.*",
     "utopia-php/dsn": "0.2.*",
-    "utopia-php/framework": "0.34.*",
+    "utopia-php/http": "0.34.*",
     "utopia-php/orchestration": "^0.19.2",
     "utopia-php/storage": "^2.0",
     "utopia-php/system": "0.10.*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d3f6bf0fe0a5f7e8f4682d9bdcf8f4d8",
+    "content-hash": "fcc19e168530cc9be6ce3a78ceb18bff",
     "packages": [
         {
             "name": "brick/math",
@@ -2119,7 +2119,7 @@
             "time": "2024-05-07T02:01:25+00:00"
         },
         {
-            "name": "utopia-php/framework",
+            "name": "utopia-php/http",
             "version": "0.34.25",
             "source": {
                 "type": "git",


### PR DESCRIPTION
## What does this PR do?

Updates the Composer dependency from `utopia-php/framework` to the renamed `utopia-php/http` package.

Both package names currently resolve to the same `utopia-php/http` repository and version, but downstream projects that also require `utopia-php/http` can install both packages at once. Since both packages autoload the same `Utopia\\` classes, Composer emits ambiguous class resolution warnings while generating optimized autoload files.

Using the current package name prevents duplicate installs and avoids those warnings for consumers.

## Test Plan

- `composer --working-dir=.worktrees/executor dump-autoload --optimize --no-interaction`
- `composer --working-dir=.worktrees/executor format:check --no-interaction`
- `composer --working-dir=.worktrees/executor analyze --no-interaction`
- `composer --working-dir=.worktrees/executor test:unit --no-interaction`
