### PR TITLE
Fix log stream hang after failed cached builds

### DIFF
--- a/src/Executor/Runner/Docker.php
+++ b/src/Executor/Runner/Docker.php
@@ -115,6 +115,10 @@ class Docker extends Adapter
         $timerId = Timer::tick($streamInterval, function () use (&$logsProcess, &$logsChunk, $response, $activeRuntimes, $runtimeName): void {
             $runtime = $activeRuntimes->get($runtimeName);
             if (!$runtime instanceof \OpenRuntimes\Executor\Runner\Runtime) {
+                if (!empty($logsProcess)) {
+                    \proc_terminate($logsProcess, 9);
+                }
+
                 return;
             }
 

--- a/src/Executor/Runner/Docker.php
+++ b/src/Executor/Runner/Docker.php
@@ -115,6 +115,11 @@ class Docker extends Adapter
         $timerId = Timer::tick($streamInterval, function () use (&$logsProcess, &$logsChunk, $response, $activeRuntimes, $runtimeName): void {
             $runtime = $activeRuntimes->get($runtimeName);
             if (!$runtime instanceof \OpenRuntimes\Executor\Runner\Runtime) {
+                if (!empty($logsChunk)) {
+                    $response->write($logsChunk);
+                    $logsChunk = '';
+                }
+
                 if (!empty($logsProcess)) {
                     \proc_terminate($logsProcess, 9);
                 }

--- a/tests/e2e/ExecutorTest.php
+++ b/tests/e2e/ExecutorTest.php
@@ -208,7 +208,7 @@ class ExecutorTest extends TestCase
 
         $this->assertIsArray($runtimeResponse);
         $this->assertEquals(400, $runtimeResponse['headers']['status-code']);
-        $this->assertStringContainsString('before-cache-failure', $runtimeResponse['body']['message']);
+        $this->assertStringContainsString('before-cache-failure', (string) $runtimeResponse['body']['message']);
         $this->assertNotEmpty($streamChunks);
         $this->assertLessThan(10, $logsDuration);
     }

--- a/tests/e2e/ExecutorTest.php
+++ b/tests/e2e/ExecutorTest.php
@@ -164,6 +164,55 @@ class ExecutorTest extends TestCase
         $validateLogs($streamChunks, false);
     }
 
+    public function testLogStreamClosesAfterFailedCachedBuild(): void
+    {
+        $runtimeId = 'test-log-stream-fail-cache-' . \bin2hex(\random_bytes(4));
+        $streamChunks = [];
+        $logsDuration = 0.0;
+        $runtimeResponse = null;
+
+        Co\run(function () use (&$streamChunks, &$logsDuration, &$runtimeResponse, $runtimeId): void {
+            $output = '';
+            $stderr = '';
+            Console::execute('cd /app/tests/resources/functions/node && tar --exclude code.tar.gz -czf code.tar.gz .', '', $output, $stderr);
+
+            Co::join([
+                Co\go(function () use (&$streamChunks, &$logsDuration, $runtimeId): void {
+                    $start = \microtime(true);
+
+                    $this->client->call(Client::METHOD_GET, '/runtimes/' . $runtimeId . '/logs', [], [
+                        'timeout' => '12'
+                    ], true, function ($data) use (&$streamChunks): void {
+                        $streamChunks[] = $data;
+                    });
+
+                    $logsDuration = \microtime(true) - $start;
+                }),
+                Co\go(function () use (&$runtimeResponse, $runtimeId): void {
+                    $params = [
+                        'runtimeId' => $runtimeId,
+                        'source' => '/storage/functions/node/code.tar.gz',
+                        'destination' => '/storage/builds/test-logs',
+                        'entrypoint' => 'index.js',
+                        'image' => 'openruntimes/node:v5-22',
+                        'workdir' => '/usr/code',
+                        'remove' => true,
+                        'cacheKey' => 'test-log-stream-fail-cache',
+                        'command' => 'echo before-cache-failure && exit 1'
+                    ];
+
+                    $runtimeResponse = $this->client->call(Client::METHOD_POST, '/runtimes', [], $params);
+                }),
+            ]);
+        });
+
+        $this->assertIsArray($runtimeResponse);
+        $this->assertEquals(400, $runtimeResponse['headers']['status-code']);
+        $this->assertStringContainsString('before-cache-failure', $runtimeResponse['body']['message']);
+        $this->assertNotEmpty($streamChunks);
+        $this->assertLessThan(10, $logsDuration);
+    }
+
     public function testUnknownPath(): void
     {
         $response = $this->client->call(Client::METHOD_GET, '/unknown', [], []);


### PR DESCRIPTION
## Summary
- terminate the active logs tail process when a runtime disappears while streaming logs
- add an E2E regression for failed cache-enabled v5 builds with concurrent `/logs`

## Verification
- `./vendor/bin/pint --test --config pint.json src/Executor/Runner/Docker.php tests/e2e/ExecutorTest.php`
- `docker run --rm --network executor_runtimes -v "$PWD":/app -w /app executor-openruntimes-executor ./vendor/bin/phpunit --configuration phpunit.xml --filter testLogStreamClosesAfterFailedCachedBuild`
- `docker run --rm --network executor_runtimes -v "$PWD":/app -w /app executor-openruntimes-executor ./vendor/bin/phpunit --configuration phpunit.xml --testsuite=unit`

## Negative Control
- temporarily removed the termination fix, rebuilt the executor, and confirmed `testLogStreamClosesAfterFailedCachedBuild` failed because `/logs` stayed open for ~13.57s instead of closing promptly