### PR TITLE
Fix Docker build cache command handling

### DIFF
--- a/src/Executor/Runner/Docker.php
+++ b/src/Executor/Runner/Docker.php
@@ -256,6 +256,7 @@ class Docker extends Adapter
         /** @var array<string, mixed> $container */
         $container = [];
         $output = [];
+        $cacheWarnings = [];
         $startTime = \microtime(true);
 
         $runtime = new Runtime(
@@ -329,8 +330,9 @@ class Docker extends Adapter
             ];
 
             $cacheEnabled = $cacheKey !== '' && $command !== '' && $command !== '0';
-            $cacheWarnings = [];
             if ($cacheEnabled) {
+                $this->validateBuildCacheKey($cacheKey);
+
                 try {
                     $this->restoreBuildCacheArtifact($cacheKey, $tmpCache, $localDevice);
                 } catch (Throwable $err) {
@@ -487,6 +489,10 @@ class Docker extends Adapter
                 ]];
             }
 
+            if ($cacheWarnings !== []) {
+                $output = \array_merge($cacheWarnings, $output);
+            }
+
             if ($remove) {
                 \sleep(2); // Allow time to read logs
             }
@@ -559,6 +565,18 @@ class Docker extends Adapter
             'timestamp' => Logs::getTimestamp(),
             'content' => '[build cache] Warning: ' . $message . "\n"
         ];
+    }
+
+    private function validateBuildCacheKey(string $cacheKey): void
+    {
+        if (
+            \str_contains($cacheKey, "\0") ||
+            \str_starts_with($cacheKey, '/') ||
+            \str_contains($cacheKey, '\\') ||
+            \preg_match('#(^|/)\.\.(?:/|$)#', $cacheKey) === 1
+        ) {
+            throw new \Exception('Invalid build cache key', 400);
+        }
     }
 
     private function restoreBuildCacheArtifact(string $cacheKey, string $tmpCache, Local $localDevice): void

--- a/src/Executor/Runner/Docker.php
+++ b/src/Executor/Runner/Docker.php
@@ -329,10 +329,19 @@ class Docker extends Adapter
             ];
 
             $cacheEnabled = $cacheKey !== '' && $command !== '' && $command !== '0';
+            $cacheWarnings = [];
             if ($cacheEnabled) {
-                $this->restoreBuildCacheArtifact($cacheKey, $tmpCache, $localDevice);
+                try {
+                    $this->restoreBuildCacheArtifact($cacheKey, $tmpCache, $localDevice);
+                } catch (Throwable $err) {
+                    $cacheWarnings[] = $this->getBuildCacheWarning('Failed to restore cache artifact: ' . $err->getMessage());
+
+                    if (!$localDevice->exists($tmpCache)) {
+                        $localDevice->createDirectory($tmpCache);
+                    }
+                }
+
                 $volumes[] = $tmpCache . ':/cache:rw';
-                $this->prepareBuildCacheScripts($command, $tmpCache);
             }
 
             if ($version === 'v5') {
@@ -361,33 +370,15 @@ class Docker extends Adapter
                 throw new \Exception('Failed to create runtime');
             }
 
-            if ($cacheEnabled) {
-                $command = 'bash /usr/local/server/helpers/build-cache.sh';
-            }
-
             /**
              * Execute any commands if they were provided
              */
             if ($command !== '' && $command !== '0') {
-                if ($version === 'v2') {
-                    $commands = [
-                        'sh',
-                        '-c',
-                        'touch /var/tmp/logs.txt && (' . $command . ') >> /var/tmp/logs.txt 2>&1 && cat /var/tmp/logs.txt'
-                    ];
-                } else {
-                    $commands = [
-                        'bash',
-                        '-c',
-                        'mkdir -p /tmp/logging && touch /tmp/logging/timings.txt && touch /tmp/logging/logs.txt && script --log-out /tmp/logging/logs.txt --flush --log-timing /tmp/logging/timings.txt --return --quiet --command "' . \str_replace('"', '\"', $command) . '"'
-                    ];
-                }
-
                 try {
                     $stdout = '';
                     $status = $this->orchestration->execute(
                         name: $runtimeName,
-                        command: $commands,
+                        command: $this->getBuildCommands($command, $version),
                         output: $stdout,
                         timeout: $timeout
                     );
@@ -402,7 +393,7 @@ class Docker extends Adapter
                             'timestamp' => Logs::getTimestamp(),
                             'content' => $stdout
                         ];
-                    } else {
+                    } elseif (!$cacheEnabled) {
                         $output = Logs::get($runtimeName);
                     }
                 } catch (Throwable $err) {
@@ -410,7 +401,17 @@ class Docker extends Adapter
                 }
 
                 if ($cacheEnabled) {
-                    $this->storeBuildCacheArtifact($cacheKey, $tmpCache, $localDevice);
+                    try {
+                        $this->storeBuildCacheArtifact($cacheKey, $tmpCache, $localDevice);
+                    } catch (Throwable $err) {
+                        $cacheWarnings[] = $this->getBuildCacheWarning('Failed to store cache artifact: ' . $err->getMessage());
+                    }
+
+                    if ($version === 'v2') {
+                        $output = \array_merge($output, $cacheWarnings);
+                    } else {
+                        $output = \array_merge($cacheWarnings, Logs::get($runtimeName));
+                    }
                 }
             }
 
@@ -529,12 +530,35 @@ class Docker extends Adapter
         return $container;
     }
 
-    private function prepareBuildCacheScripts(string $command, string $tmpCache): void
+    /**
+     * @return string[]
+     */
+    private function getBuildCommands(string $command, string $version): array
     {
-        $commandScript = "#!/bin/sh\n" . $command . "\n";
-        if (\file_put_contents($tmpCache . '/build-command.sh', $commandScript) === false) {
-            throw new \Exception('Failed to prepare build command script');
+        if ($version === 'v2') {
+            return [
+                'sh',
+                '-c',
+                'touch /var/tmp/logs.txt && (' . $command . ') >> /var/tmp/logs.txt 2>&1 && cat /var/tmp/logs.txt'
+            ];
         }
+
+        return [
+            'bash',
+            '-c',
+            'mkdir -p /tmp/logging && touch /tmp/logging/timings.txt && touch /tmp/logging/logs.txt && script --log-out /tmp/logging/logs.txt --flush --log-timing /tmp/logging/timings.txt --return --quiet --command "' . \str_replace('"', '\"', $command) . '"'
+        ];
+    }
+
+    /**
+     * @return array{timestamp: string, content: string}
+     */
+    private function getBuildCacheWarning(string $message): array
+    {
+        return [
+            'timestamp' => Logs::getTimestamp(),
+            'content' => '[build cache] Warning: ' . $message . "\n"
+        ];
     }
 
     private function restoreBuildCacheArtifact(string $cacheKey, string $tmpCache, Local $localDevice): void

--- a/tests/e2e/ExecutorTest.php
+++ b/tests/e2e/ExecutorTest.php
@@ -644,7 +644,7 @@ class ExecutorTest extends TestCase
             $firstBuildOutput .= $outputItem['content'];
         }
 
-        $this->assertStringContainsString('[build cache] Saved.', $firstBuildOutput);
+        $this->assertStringContainsString('Build cache saved.', $firstBuildOutput);
 
         $params = [
             'runtimeId' => 'test-build-cache-hit-' . $runtimeId,
@@ -665,7 +665,7 @@ class ExecutorTest extends TestCase
             $secondBuildOutput .= $outputItem['content'];
         }
 
-        $this->assertStringContainsString('[build cache] Hit.', $secondBuildOutput);
+        $this->assertStringContainsString('Build cache hit.', $secondBuildOutput);
 
         $this->assertNotEmpty($response['body']['path']);
 

--- a/tests/unit/Executor/Runner/DockerTest.php
+++ b/tests/unit/Executor/Runner/DockerTest.php
@@ -18,8 +18,8 @@ final class DockerTest extends TestCase
 
         $this->assertSame('bash', $commands[0]);
         $this->assertStringContainsString('echo original-user-command', $commands[2]);
-        $this->assertStringNotContainsString('build-' . 'cache.sh', $commands[2]);
-        $this->assertStringNotContainsString('/cache/' . 'build-' . 'command.sh', $commands[2]);
+        $this->assertStringNotContainsString('build-cache.sh', $commands[2]);
+        $this->assertStringNotContainsString('/cache/build-command.sh', $commands[2]);
     }
 
     public function testNoBuildCommandScriptReferenceRemains(): void
@@ -28,7 +28,7 @@ final class DockerTest extends TestCase
 
         foreach (['v2', 'v5'] as $version) {
             $commands = $this->invokeGetBuildCommands($docker, 'echo test', $version);
-            $this->assertStringNotContainsString('/cache/' . 'build-' . 'command.sh', \implode(' ', $commands));
+            $this->assertStringNotContainsString('/cache/build-command.sh', \implode(' ', $commands));
         }
     }
 
@@ -38,10 +38,10 @@ final class DockerTest extends TestCase
         $commands = $this->invokeGetBuildCommands($docker, 'npm install', 'v5');
         $command = \implode(' ', $commands);
 
-        $this->assertStringNotContainsString('restore-' . 'build-' . 'cache.sh', $command);
-        $this->assertStringNotContainsString('save-' . 'build-' . 'cache.sh', $command);
-        $this->assertStringNotContainsString('build-cache-' . 'restore.sh', $command);
-        $this->assertStringNotContainsString('build-cache-' . 'save.sh', $command);
+        $this->assertStringNotContainsString('restore-build-cache.sh', $command);
+        $this->assertStringNotContainsString('save-build-cache.sh', $command);
+        $this->assertStringNotContainsString('build-cache-restore.sh', $command);
+        $this->assertStringNotContainsString('build-cache-save.sh', $command);
     }
 
     /**

--- a/tests/unit/Executor/Runner/DockerTest.php
+++ b/tests/unit/Executor/Runner/DockerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Executor\Runner;
+
+use OpenRuntimes\Executor\Runner\Docker;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+
+final class DockerTest extends TestCase
+{
+    public function testBuildCommandsUseOriginalUserCommand(): void
+    {
+        $docker = $this->createDocker();
+        $commands = $this->invokeGetBuildCommands($docker, 'echo original-user-command', 'v5');
+
+        $this->assertSame('bash', $commands[0]);
+        $this->assertStringContainsString('echo original-user-command', $commands[2]);
+        $this->assertStringNotContainsString('build-' . 'cache.sh', $commands[2]);
+        $this->assertStringNotContainsString('/cache/' . 'build-' . 'command.sh', $commands[2]);
+    }
+
+    public function testNoBuildCommandScriptReferenceRemains(): void
+    {
+        $docker = $this->createDocker();
+
+        foreach (['v2', 'v5'] as $version) {
+            $commands = $this->invokeGetBuildCommands($docker, 'echo test', $version);
+            $this->assertStringNotContainsString('/cache/' . 'build-' . 'command.sh', \implode(' ', $commands));
+        }
+    }
+
+    public function testNoCacheLifecycleShellCommandsAreGenerated(): void
+    {
+        $docker = $this->createDocker();
+        $commands = $this->invokeGetBuildCommands($docker, 'npm install', 'v5');
+        $command = \implode(' ', $commands);
+
+        $this->assertStringNotContainsString('restore-' . 'build-' . 'cache.sh', $command);
+        $this->assertStringNotContainsString('save-' . 'build-' . 'cache.sh', $command);
+        $this->assertStringNotContainsString('build-cache-' . 'restore.sh', $command);
+        $this->assertStringNotContainsString('build-cache-' . 'save.sh', $command);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function invokeGetBuildCommands(Docker $docker, string $command, string $version): array
+    {
+        $method = new ReflectionMethod(Docker::class, 'getBuildCommands');
+
+        return $method->invoke($docker, $command, $version);
+    }
+
+    private function createDocker(): Docker
+    {
+        $reflection = new ReflectionClass(Docker::class);
+        return $reflection->newInstanceWithoutConstructor();
+    }
+}

--- a/tests/unit/Executor/Runner/DockerTest.php
+++ b/tests/unit/Executor/Runner/DockerTest.php
@@ -44,6 +44,15 @@ final class DockerTest extends TestCase
         $this->assertStringNotContainsString('build-cache-save.sh', $command);
     }
 
+    public function testInvalidBuildCacheKeyIsRejected(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionCode(400);
+
+        $method = new ReflectionMethod(Docker::class, 'validateBuildCacheKey');
+        $method->invoke($this->createDocker(), '..');
+    }
+
     /**
      * @return string[]
      */


### PR DESCRIPTION
## Summary
- keep Docker builds running the original user command when build cache is enabled
- remove generated cache command script usage from the Docker executor
- keep cache artifact restore/upload best-effort and preserve cache warnings in build output
- add unit coverage for avoiding cache wrapper/lifecycle command generation

## Tests
- ./vendor/bin/phpunit --configuration phpunit.xml --testsuite=unit --filter DockerTest
- ./vendor/bin/pint --test --config pint.json src/Executor/Runner/Docker.php tests/unit/Executor/Runner/DockerTest.php