### PR TITLE
Report silent build command failures

### DIFF
--- a/app/config/errors.php
+++ b/app/config/errors.php
@@ -24,6 +24,14 @@ return [
         'message' => 'You are not authorized to access this resource.',
         'code' => 401,
     ],
+    /* Build */
+    Exception::BUILD_FAILED  => [
+        'name' => Exception::BUILD_FAILED,
+        'short' => 'Build failed',
+        'message' => 'Build failed.',
+        'code' => 400,
+        'publish' => false,
+    ],
     /* Runtime */
     Exception::RUNTIME_FAILED  => [
         'name' => Exception::RUNTIME_FAILED,

--- a/src/Executor/Exception.php
+++ b/src/Executor/Exception.php
@@ -24,6 +24,8 @@ class Exception extends \RuntimeException
 
     public const string EXECUTION_BAD_JSON    = 'execution_bad_json';
 
+    public const string BUILD_FAILED       = 'build_failed';
+
     public const string RUNTIME_NOT_FOUND    = 'runtime_not_found';
 
     public const string RUNTIME_CONFLICT     = 'runtime_conflict';

--- a/src/Executor/Runner/Docker.php
+++ b/src/Executor/Runner/Docker.php
@@ -387,7 +387,7 @@ class Docker extends Adapter
                     );
 
                     if (!$status) {
-                        $message = \trim($stdout);
+                        $message = \trim(\mb_strcut($stdout, 0, MAX_BUILD_LOG_SIZE));
 
                         throw new ExecutorException(
                             ExecutorException::BUILD_FAILED,
@@ -407,7 +407,7 @@ class Docker extends Adapter
                 } catch (ExecutorException $err) {
                     throw $err;
                 } catch (OrchestrationException $err) {
-                    $message = \trim($stdout);
+                    $message = \trim(\mb_strcut($stdout, 0, MAX_BUILD_LOG_SIZE));
 
                     throw new ExecutorException(
                         ExecutorException::BUILD_FAILED,

--- a/src/Executor/Runner/Docker.php
+++ b/src/Executor/Runner/Docker.php
@@ -376,8 +376,9 @@ class Docker extends Adapter
              * Execute any commands if they were provided
              */
             if ($command !== '' && $command !== '0') {
+                $stdout = '';
+
                 try {
-                    $stdout = '';
                     $status = $this->orchestration->execute(
                         name: $runtimeName,
                         command: $this->getBuildCommands($command, $version),
@@ -386,7 +387,12 @@ class Docker extends Adapter
                     );
 
                     if (!$status) {
-                        throw new ExecutorException(ExecutorException::RUNTIME_FAILED, 'Failed to create runtime: ' . $stdout);
+                        $message = \trim($stdout);
+
+                        throw new ExecutorException(
+                            ExecutorException::BUILD_FAILED,
+                            $message === '' ? 'Build command failed.' : $message
+                        );
                     }
 
                     if ($version === 'v2') {
@@ -398,6 +404,16 @@ class Docker extends Adapter
                     } elseif (!$cacheEnabled) {
                         $output = Logs::get($runtimeName);
                     }
+                } catch (ExecutorException $err) {
+                    throw $err;
+                } catch (OrchestrationException $err) {
+                    $message = \trim($stdout);
+
+                    throw new ExecutorException(
+                        ExecutorException::BUILD_FAILED,
+                        $message === '' ? 'Build command failed.' : $message,
+                        previous: $err
+                    );
                 } catch (Throwable $err) {
                     throw new ExecutorException(ExecutorException::RUNTIME_FAILED, $err->getMessage(), null, $err);
                 }
@@ -511,6 +527,26 @@ class Docker extends Adapter
                 $message .= $chunk['content'];
             }
 
+            if ($throwable instanceof ExecutorException) {
+                $throwableMessage = \trim($throwable->getMessage());
+
+                if ($message !== '' && \str_starts_with($throwableMessage, $message)) {
+                    $throwableMessage = \trim(\substr($throwableMessage, \strlen($message)));
+                }
+
+                if ($throwableMessage !== '' && ! \str_contains($message, $throwableMessage)) {
+                    $remaining = MAX_BUILD_LOG_SIZE - \strlen($message);
+                    $remaining -= $message === '' ? 0 : 1;
+
+                    if ($remaining > 0) {
+                        $throwableMessage = \mb_strcut($throwableMessage, 0, $remaining);
+                        $message .= $message === '' ? $throwableMessage : "\n" . $throwableMessage;
+                    }
+                }
+
+                throw new ExecutorException($throwable->getType(), $message, $throwable->getCode(), $throwable);
+            }
+
             throw new \Exception($message, $throwable->getCode() ?: 500, $throwable);
         }
 
@@ -545,14 +581,14 @@ class Docker extends Adapter
             return [
                 'sh',
                 '-c',
-                'touch /var/tmp/logs.txt && (' . $command . ') >> /var/tmp/logs.txt 2>&1 && cat /var/tmp/logs.txt'
+                'touch /var/tmp/logs.txt && (' . $command . ') >> /var/tmp/logs.txt 2>&1; status=$?; cat /var/tmp/logs.txt; if [ $status -ne 0 ]; then echo "Build command exited with code $status."; fi; exit $status'
             ];
         }
 
         return [
             'bash',
             '-c',
-            'mkdir -p /tmp/logging && touch /tmp/logging/timings.txt && touch /tmp/logging/logs.txt && script --log-out /tmp/logging/logs.txt --flush --log-timing /tmp/logging/timings.txt --return --quiet --command "' . \str_replace('"', '\"', $command) . '"'
+            'mkdir -p /tmp/logging && touch /tmp/logging/timings.txt && touch /tmp/logging/logs.txt && script --log-out /tmp/logging/logs.txt --flush --log-timing /tmp/logging/timings.txt --return --quiet --command "' . \str_replace('"', '\"', $command) . '"; status=$?; if [ $status -ne 0 ]; then echo "Build command exited with code $status."; fi; exit $status'
         ];
     }
 

--- a/src/Executor/Runner/Docker.php
+++ b/src/Executor/Runner/Docker.php
@@ -522,29 +522,13 @@ class Docker extends Adapter
             $localDevice->deletePath($tmpFolder);
             $this->runtimes->remove($runtimeName);
 
+            if ($throwable instanceof ExecutorException) {
+                throw $throwable;
+            }
+
             $message = '';
             foreach ($output as $chunk) {
                 $message .= $chunk['content'];
-            }
-
-            if ($throwable instanceof ExecutorException) {
-                $throwableMessage = \trim($throwable->getMessage());
-
-                if ($message !== '' && \str_starts_with($throwableMessage, $message)) {
-                    $throwableMessage = \trim(\substr($throwableMessage, \strlen($message)));
-                }
-
-                if ($throwableMessage !== '' && ! \str_contains($message, $throwableMessage)) {
-                    $remaining = MAX_BUILD_LOG_SIZE - \strlen($message);
-                    $remaining -= $message === '' ? 0 : 1;
-
-                    if ($remaining > 0) {
-                        $throwableMessage = \mb_strcut($throwableMessage, 0, $remaining);
-                        $message .= $message === '' ? $throwableMessage : "\n" . $throwableMessage;
-                    }
-                }
-
-                throw new ExecutorException($throwable->getType(), $message, $throwable->getCode(), $throwable);
             }
 
             throw new \Exception($message, $throwable->getCode() ?: 500, $throwable);

--- a/tests/e2e/ExecutorTest.php
+++ b/tests/e2e/ExecutorTest.php
@@ -301,6 +301,22 @@ class ExecutorTest extends TestCase
         $this->assertEquals(400, $response['headers']['status-code']);
         $this->assertEquals('build_failed', $response['body']['type']);
 
+        /** Silent user error in build command */
+        $params = [
+            'runtimeId' => 'test-build-fail-silent-' . $runtimeId,
+            'source' => '/storage/functions/php/code.tar.gz',
+            'destination' => '/storage/builds/test',
+            'entrypoint' => 'index.php',
+            'image' => 'openruntimes/php:v5-8.1',
+            'command' => 'exit 1',
+            'remove' => true
+        ];
+
+        $response = $this->client->call(Client::METHOD_POST, '/runtimes', [], $params);
+        $this->assertEquals(400, $response['headers']['status-code']);
+        $this->assertEquals('build_failed', $response['body']['type']);
+        $this->assertStringContainsString('Build command exited with code 1.', $response['body']['message']);
+
         /** Invalid cache key */
         $params = [
             'runtimeId' => 'test-build-fail-cache-key-' . $runtimeId,

--- a/tests/e2e/ExecutorTest.php
+++ b/tests/e2e/ExecutorTest.php
@@ -299,6 +299,7 @@ class ExecutorTest extends TestCase
 
         $response = $this->client->call(Client::METHOD_POST, '/runtimes', [], $params);
         $this->assertEquals(400, $response['headers']['status-code']);
+        $this->assertEquals('build_failed', $response['body']['type']);
 
         /** Invalid cache key */
         $params = [

--- a/tests/e2e/ExecutorTest.php
+++ b/tests/e2e/ExecutorTest.php
@@ -315,7 +315,7 @@ class ExecutorTest extends TestCase
         $response = $this->client->call(Client::METHOD_POST, '/runtimes', [], $params);
         $this->assertEquals(400, $response['headers']['status-code']);
         $this->assertEquals('build_failed', $response['body']['type']);
-        $this->assertStringContainsString('Build command exited with code 1.', $response['body']['message']);
+        $this->assertStringContainsString('Build command exited with code 1.', (string) $response['body']['message']);
 
         /** Invalid cache key */
         $params = [

--- a/tests/unit/Executor/Runner/DockerTest.php
+++ b/tests/unit/Executor/Runner/DockerTest.php
@@ -44,6 +44,19 @@ final class DockerTest extends TestCase
         $this->assertStringNotContainsString('build-cache-save.sh', $command);
     }
 
+    public function testBuildCommandsReportSilentNonZeroExit(): void
+    {
+        $docker = $this->createDocker();
+
+        foreach (['v2', 'v5'] as $version) {
+            $commands = $this->invokeGetBuildCommands($docker, 'exit 1', $version);
+            $command = \implode(' ', $commands);
+
+            $this->assertStringContainsString('Build command exited with code $status.', $command);
+            $this->assertStringContainsString('exit $status', $command);
+        }
+    }
+
     public function testInvalidBuildCacheKeyIsRejected(): void
     {
         $this->expectException(\Exception::class);


### PR DESCRIPTION
## What does this PR do?

Makes build command failures explicit in executor responses by introducing a dedicated `build_failed` error type.

Previously, a build command that exited non-zero could be surfaced as a generic runtime failure. With the Docker API orchestration adapter, non-zero command exits are raised as orchestration exceptions, so executor never reached its existing `$status === false` handling. That caused user build failures to lose their intended classification.

This PR keeps the fix local to executor:

- Adds `Exception::BUILD_FAILED = 'build_failed'`.
- Adds `build_failed` to the error config with HTTP 400 and `publish => false`.
- Maps orchestration exceptions from the build-command execution step to `BUILD_FAILED`.
- Keeps generic runtime/container errors mapped to `runtime_failed`.
- Preserves existing `ExecutorException` types through the outer cleanup path instead of wrapping them as generic exceptions.
- Keeps the build shell wrapper fallback for silent non-zero exits: `Build command exited with code N.`
- Adds focused unit coverage for the build command wrapper fallback.
- Adds e2e coverage asserting build command failures return `type: build_failed`.

## Why

Downstream services need to distinguish user build failures from executor/runtime infrastructure failures. `build_failed` is safe to present as a user build error, while generic runtime failures can remain internal.

## Test Plan

- `composer test:unit -- --filter DockerTest`

## Related PRs and Issues

- Appwrite consumer PR: https://github.com/appwrite/appwrite/pull/12724
- #XXXX
