### PR TITLE
fix: restore StorageFactory legacy env fallback and S3 bucket root

### DIFF
--- a/src/Executor/StorageFactory.php
+++ b/src/Executor/StorageFactory.php
@@ -15,6 +15,7 @@ use Utopia\Storage\Device\S3;
 use Utopia\Storage\Device\Wasabi;
 use Utopia\Storage\Device;
 use Utopia\Storage\Storage;
+use Utopia\System\System;
 
 class StorageFactory
 {
@@ -27,6 +28,13 @@ class StorageFactory
     public static function getDevice(string $root, ?string $connection = ''): Device
     {
         $connection ??= '';
+
+        // Appwrite compose still ships OPR_EXECUTOR_CONNECTION_STORAGE=local://localhost
+        // while configuring remote storage via OPR_EXECUTOR_STORAGE_* env vars.
+        if (self::shouldUseEnvFallback($connection)) {
+            return self::getDeviceFromEnv($root);
+        }
+
         $acl = 'private';
         $deviceType = Storage::DEVICE_LOCAL;
         $accessKey = '';
@@ -43,7 +51,7 @@ class StorageFactory
             $accessKey = $dsn->getUser() ?? '';
             $accessSecret = $dsn->getPassword() ?? '';
             $host = $dsn->getHost();
-            $bucket = $dsn->getPath() ?? '';
+            $bucket = \ltrim($dsn->getPath() ?? '', '/');
             $dsnRegion = $dsn->getParam('region');
             $insecure = $dsn->getParam('insecure', 'false') === 'true';
             $url = $dsn->getParam('url', '');
@@ -55,12 +63,12 @@ class StorageFactory
         switch ($deviceType) {
             case Storage::DEVICE_S3:
                 if ($url !== '' && $url !== '0') {
-                    return new S3($root, $accessKey, $accessSecret, $url, $dsnRegion, $acl);
+                    return new S3(self::withBucketRoot($root, $bucket), $accessKey, $accessSecret, $url, $dsnRegion, $acl);
                 }
 
                 if ($host !== '' && $host !== '0') {
                     $host = $insecure ? 'http://' . $host : $host;
-                    return new S3(root: $root, accessKey: $accessKey, secretKey: $accessSecret, host: $host, region: $dsnRegion, acl: $acl);
+                    return new S3(root: self::withBucketRoot($root, $bucket), accessKey: $accessKey, secretKey: $accessSecret, host: $host, region: $dsnRegion, acl: $acl);
                 }
 
                 return new AWS(root: $root, accessKey: $accessKey, secretKey: $accessSecret, bucket: $bucket, region: $dsnRegion, acl: $acl);
@@ -81,5 +89,113 @@ class StorageFactory
             default:
                 return new Local($root);
         }
+    }
+
+    /**
+     * Fall back to OPR_EXECUTOR_STORAGE_* when CONNECTION_STORAGE is empty or the local default.
+     */
+    private static function shouldUseEnvFallback(string $connection): bool
+    {
+        $device = \strtolower(System::getEnv('OPR_EXECUTOR_STORAGE_DEVICE', Storage::DEVICE_LOCAL) ?? Storage::DEVICE_LOCAL);
+        if ($device === '' || $device === Storage::DEVICE_LOCAL) {
+            return false;
+        }
+
+        if ($connection === '') {
+            return true;
+        }
+
+        return \in_array($connection, [
+            'local://localhost',
+            'file://localhost',
+            'local://',
+            'file://',
+        ], true);
+    }
+
+    /**
+     * Get storage device from legacy OPR_EXECUTOR_STORAGE_* environment variables.
+     */
+    private static function getDeviceFromEnv(string $root): Device
+    {
+        $acl = 'private';
+
+        switch (\strtolower(System::getEnv('OPR_EXECUTOR_STORAGE_DEVICE', Storage::DEVICE_LOCAL) ?? Storage::DEVICE_LOCAL)) {
+            case Storage::DEVICE_S3:
+                $accessKey = System::getEnv('OPR_EXECUTOR_STORAGE_S3_ACCESS_KEY', '') ?? '';
+                $secretKey = System::getEnv('OPR_EXECUTOR_STORAGE_S3_SECRET', '') ?? '';
+                $host = System::getEnv('OPR_EXECUTOR_STORAGE_S3_HOST', '') ?? '';
+                $region = System::getEnv('OPR_EXECUTOR_STORAGE_S3_REGION', '') ?? '';
+                $bucket = System::getEnv('OPR_EXECUTOR_STORAGE_S3_BUCKET', '') ?? '';
+                $endpointUrl = System::getEnv('OPR_EXECUTOR_STORAGE_S3_ENDPOINT', '') ?? '';
+
+                if ($endpointUrl !== '' && $endpointUrl !== '0') {
+                    return new S3(self::withBucketRoot($root, $bucket), $accessKey, $secretKey, $endpointUrl, $region, $acl);
+                }
+
+                if ($host !== '' && $host !== '0') {
+                    return new S3(root: self::withBucketRoot($root, $bucket), accessKey: $accessKey, secretKey: $secretKey, host: $host, region: $region, acl: $acl);
+                }
+
+                return new AWS(root: $root, accessKey: $accessKey, secretKey: $secretKey, bucket: $bucket, region: $region, acl: $acl);
+
+            case Storage::DEVICE_DO_SPACES:
+                return new DOSpaces(
+                    $root,
+                    System::getEnv('OPR_EXECUTOR_STORAGE_DO_SPACES_ACCESS_KEY', '') ?? '',
+                    System::getEnv('OPR_EXECUTOR_STORAGE_DO_SPACES_SECRET', '') ?? '',
+                    System::getEnv('OPR_EXECUTOR_STORAGE_DO_SPACES_BUCKET', '') ?? '',
+                    System::getEnv('OPR_EXECUTOR_STORAGE_DO_SPACES_REGION', '') ?? '',
+                    $acl
+                );
+
+            case Storage::DEVICE_BACKBLAZE:
+                return new Backblaze(
+                    $root,
+                    System::getEnv('OPR_EXECUTOR_STORAGE_BACKBLAZE_ACCESS_KEY', '') ?? '',
+                    System::getEnv('OPR_EXECUTOR_STORAGE_BACKBLAZE_SECRET', '') ?? '',
+                    System::getEnv('OPR_EXECUTOR_STORAGE_BACKBLAZE_BUCKET', '') ?? '',
+                    System::getEnv('OPR_EXECUTOR_STORAGE_BACKBLAZE_REGION', '') ?? '',
+                    $acl
+                );
+
+            case Storage::DEVICE_LINODE:
+                return new Linode(
+                    $root,
+                    System::getEnv('OPR_EXECUTOR_STORAGE_LINODE_ACCESS_KEY', '') ?? '',
+                    System::getEnv('OPR_EXECUTOR_STORAGE_LINODE_SECRET', '') ?? '',
+                    System::getEnv('OPR_EXECUTOR_STORAGE_LINODE_BUCKET', '') ?? '',
+                    System::getEnv('OPR_EXECUTOR_STORAGE_LINODE_REGION', '') ?? '',
+                    $acl
+                );
+
+            case Storage::DEVICE_WASABI:
+                return new Wasabi(
+                    $root,
+                    System::getEnv('OPR_EXECUTOR_STORAGE_WASABI_ACCESS_KEY', '') ?? '',
+                    System::getEnv('OPR_EXECUTOR_STORAGE_WASABI_SECRET', '') ?? '',
+                    System::getEnv('OPR_EXECUTOR_STORAGE_WASABI_BUCKET', '') ?? '',
+                    System::getEnv('OPR_EXECUTOR_STORAGE_WASABI_REGION', '') ?? '',
+                    $acl
+                );
+
+            case Storage::DEVICE_LOCAL:
+            default:
+                return new Local($root);
+        }
+    }
+
+    /**
+     * Generic S3 devices encode the bucket in the root path.
+     */
+    private static function withBucketRoot(string $root, string $bucket): string
+    {
+        $bucket = \ltrim($bucket, '/');
+
+        if ($bucket === '') {
+            return $root;
+        }
+
+        return $bucket . '/' . \ltrim($root, '/');
     }
 }

--- a/src/Executor/StorageFactory.php
+++ b/src/Executor/StorageFactory.php
@@ -96,7 +96,7 @@ class StorageFactory
      */
     private static function shouldUseEnvFallback(string $connection): bool
     {
-        $device = \strtolower(System::getEnv('OPR_EXECUTOR_STORAGE_DEVICE', Storage::DEVICE_LOCAL) ?? Storage::DEVICE_LOCAL);
+        $device = \strtolower(System::getEnv('OPR_EXECUTOR_STORAGE_DEVICE', Storage::DEVICE_LOCAL));
         if ($device === '' || $device === Storage::DEVICE_LOCAL) {
             return false;
         }
@@ -120,14 +120,14 @@ class StorageFactory
     {
         $acl = 'private';
 
-        switch (\strtolower(System::getEnv('OPR_EXECUTOR_STORAGE_DEVICE', Storage::DEVICE_LOCAL) ?? Storage::DEVICE_LOCAL)) {
+        switch (\strtolower(System::getEnv('OPR_EXECUTOR_STORAGE_DEVICE', Storage::DEVICE_LOCAL))) {
             case Storage::DEVICE_S3:
-                $accessKey = System::getEnv('OPR_EXECUTOR_STORAGE_S3_ACCESS_KEY', '') ?? '';
-                $secretKey = System::getEnv('OPR_EXECUTOR_STORAGE_S3_SECRET', '') ?? '';
-                $host = System::getEnv('OPR_EXECUTOR_STORAGE_S3_HOST', '') ?? '';
-                $region = System::getEnv('OPR_EXECUTOR_STORAGE_S3_REGION', '') ?? '';
-                $bucket = System::getEnv('OPR_EXECUTOR_STORAGE_S3_BUCKET', '') ?? '';
-                $endpointUrl = System::getEnv('OPR_EXECUTOR_STORAGE_S3_ENDPOINT', '') ?? '';
+                $accessKey = System::getEnv('OPR_EXECUTOR_STORAGE_S3_ACCESS_KEY', '');
+                $secretKey = System::getEnv('OPR_EXECUTOR_STORAGE_S3_SECRET', '');
+                $host = System::getEnv('OPR_EXECUTOR_STORAGE_S3_HOST', '');
+                $region = System::getEnv('OPR_EXECUTOR_STORAGE_S3_REGION', '');
+                $bucket = System::getEnv('OPR_EXECUTOR_STORAGE_S3_BUCKET', '');
+                $endpointUrl = System::getEnv('OPR_EXECUTOR_STORAGE_S3_ENDPOINT', '');
 
                 if ($endpointUrl !== '' && $endpointUrl !== '0') {
                     return new S3(self::withBucketRoot($root, $bucket), $accessKey, $secretKey, $endpointUrl, $region, $acl);
@@ -142,40 +142,40 @@ class StorageFactory
             case Storage::DEVICE_DO_SPACES:
                 return new DOSpaces(
                     $root,
-                    System::getEnv('OPR_EXECUTOR_STORAGE_DO_SPACES_ACCESS_KEY', '') ?? '',
-                    System::getEnv('OPR_EXECUTOR_STORAGE_DO_SPACES_SECRET', '') ?? '',
-                    System::getEnv('OPR_EXECUTOR_STORAGE_DO_SPACES_BUCKET', '') ?? '',
-                    System::getEnv('OPR_EXECUTOR_STORAGE_DO_SPACES_REGION', '') ?? '',
+                    System::getEnv('OPR_EXECUTOR_STORAGE_DO_SPACES_ACCESS_KEY', ''),
+                    System::getEnv('OPR_EXECUTOR_STORAGE_DO_SPACES_SECRET', ''),
+                    System::getEnv('OPR_EXECUTOR_STORAGE_DO_SPACES_BUCKET', ''),
+                    System::getEnv('OPR_EXECUTOR_STORAGE_DO_SPACES_REGION', ''),
                     $acl
                 );
 
             case Storage::DEVICE_BACKBLAZE:
                 return new Backblaze(
                     $root,
-                    System::getEnv('OPR_EXECUTOR_STORAGE_BACKBLAZE_ACCESS_KEY', '') ?? '',
-                    System::getEnv('OPR_EXECUTOR_STORAGE_BACKBLAZE_SECRET', '') ?? '',
-                    System::getEnv('OPR_EXECUTOR_STORAGE_BACKBLAZE_BUCKET', '') ?? '',
-                    System::getEnv('OPR_EXECUTOR_STORAGE_BACKBLAZE_REGION', '') ?? '',
+                    System::getEnv('OPR_EXECUTOR_STORAGE_BACKBLAZE_ACCESS_KEY', ''),
+                    System::getEnv('OPR_EXECUTOR_STORAGE_BACKBLAZE_SECRET', ''),
+                    System::getEnv('OPR_EXECUTOR_STORAGE_BACKBLAZE_BUCKET', ''),
+                    System::getEnv('OPR_EXECUTOR_STORAGE_BACKBLAZE_REGION', ''),
                     $acl
                 );
 
             case Storage::DEVICE_LINODE:
                 return new Linode(
                     $root,
-                    System::getEnv('OPR_EXECUTOR_STORAGE_LINODE_ACCESS_KEY', '') ?? '',
-                    System::getEnv('OPR_EXECUTOR_STORAGE_LINODE_SECRET', '') ?? '',
-                    System::getEnv('OPR_EXECUTOR_STORAGE_LINODE_BUCKET', '') ?? '',
-                    System::getEnv('OPR_EXECUTOR_STORAGE_LINODE_REGION', '') ?? '',
+                    System::getEnv('OPR_EXECUTOR_STORAGE_LINODE_ACCESS_KEY', ''),
+                    System::getEnv('OPR_EXECUTOR_STORAGE_LINODE_SECRET', ''),
+                    System::getEnv('OPR_EXECUTOR_STORAGE_LINODE_BUCKET', ''),
+                    System::getEnv('OPR_EXECUTOR_STORAGE_LINODE_REGION', ''),
                     $acl
                 );
 
             case Storage::DEVICE_WASABI:
                 return new Wasabi(
                     $root,
-                    System::getEnv('OPR_EXECUTOR_STORAGE_WASABI_ACCESS_KEY', '') ?? '',
-                    System::getEnv('OPR_EXECUTOR_STORAGE_WASABI_SECRET', '') ?? '',
-                    System::getEnv('OPR_EXECUTOR_STORAGE_WASABI_BUCKET', '') ?? '',
-                    System::getEnv('OPR_EXECUTOR_STORAGE_WASABI_REGION', '') ?? '',
+                    System::getEnv('OPR_EXECUTOR_STORAGE_WASABI_ACCESS_KEY', ''),
+                    System::getEnv('OPR_EXECUTOR_STORAGE_WASABI_SECRET', ''),
+                    System::getEnv('OPR_EXECUTOR_STORAGE_WASABI_BUCKET', ''),
+                    System::getEnv('OPR_EXECUTOR_STORAGE_WASABI_REGION', ''),
                     $acl
                 );
 

--- a/src/Executor/StorageFactory.php
+++ b/src/Executor/StorageFactory.php
@@ -63,12 +63,12 @@ class StorageFactory
         switch ($deviceType) {
             case Storage::DEVICE_S3:
                 if ($url !== '' && $url !== '0') {
-                    return new S3(self::withBucketRoot($root, $bucket), $accessKey, $accessSecret, $url, $dsnRegion, $acl);
+                    return new S3($root, $accessKey, $accessSecret, $url, $dsnRegion, $acl);
                 }
 
                 if ($host !== '' && $host !== '0') {
                     $host = $insecure ? 'http://' . $host : $host;
-                    return new S3(root: self::withBucketRoot($root, $bucket), accessKey: $accessKey, secretKey: $accessSecret, host: $host, region: $dsnRegion, acl: $acl);
+                    return new S3(root: $root, accessKey: $accessKey, secretKey: $accessSecret, host: $host, region: $dsnRegion, acl: $acl);
                 }
 
                 return new AWS(root: $root, accessKey: $accessKey, secretKey: $accessSecret, bucket: $bucket, region: $dsnRegion, acl: $acl);
@@ -105,12 +105,14 @@ class StorageFactory
             return true;
         }
 
-        return \in_array($connection, [
-            'local://localhost',
-            'file://localhost',
-            'local://',
-            'file://',
-        ], true);
+        try {
+            $scheme = \strtolower((new DSN($connection))->getScheme() ?? '');
+        } catch (\Throwable) {
+            return false;
+        }
+
+        // Appwrite compose defaults CONNECTION_STORAGE to a local placeholder DSN.
+        return $scheme === Storage::DEVICE_LOCAL || $scheme === 'file' || $scheme === 'local';
     }
 
     /**

--- a/src/Executor/StorageFactory.php
+++ b/src/Executor/StorageFactory.php
@@ -106,13 +106,13 @@ class StorageFactory
         }
 
         try {
-            $scheme = \strtolower((new DSN($connection))->getScheme() ?? '');
+            $scheme = \strtolower((new DSN($connection))->getScheme());
         } catch (\Throwable) {
             return false;
         }
 
         // Appwrite compose defaults CONNECTION_STORAGE to a local placeholder DSN.
-        return $scheme === Storage::DEVICE_LOCAL || $scheme === 'file' || $scheme === 'local';
+        return $scheme === Storage::DEVICE_LOCAL || $scheme === 'file';
     }
 
     /**

--- a/src/Executor/StorageFactory.php
+++ b/src/Executor/StorageFactory.php
@@ -106,7 +106,7 @@ class StorageFactory
         }
 
         try {
-            $scheme = \strtolower((new DSN($connection))->getScheme());
+            $scheme = \strtolower(new DSN($connection)->getScheme());
         } catch (\Throwable) {
             return false;
         }


### PR DESCRIPTION
## What does this PR do?

Restores remote-storage support for self-hosted Appwrite setups that still configure the executor with legacy `OPR_EXECUTOR_STORAGE_*` env vars while `OPR_EXECUTOR_CONNECTION_STORAGE` defaults to `local://localhost`.

After the StorageFactory refactor, those legacy vars were ignored, so custom S3 (and other providers) no longer received the bucket/credentials. This also prepends the bucket to the root path for generic S3 devices (endpoint/host), matching the previous Adapter behavior.

## Test Plan

1. With `OPR_EXECUTOR_CONNECTION_STORAGE=local://localhost` and:
   - `OPR_EXECUTOR_STORAGE_DEVICE=s3`
   - `OPR_EXECUTOR_STORAGE_S3_*` (access key, secret, region, bucket, endpoint)
2. Confirm `StorageFactory::getDevice('/')` returns an S3 device whose root includes the bucket
3. Deploy a function/site artifact and verify the executor can read/write the remote bucket
4. With a real DSN (`s3://key:secret@host/bucket?region=...`), confirm bucket is still applied to the S3 root

## Related

- Thread: Executor with custom S3 doesn't work in appwrite 1.9.5 (executor 0.25.1)
- Appwrite compose still passes `OPR_EXECUTOR_STORAGE_*` alongside `CONNECTION_STORAGE=local://localhost`
