### PR TITLE
Fix S3 bucket prefix omission for custom endpoints in StorageFactory

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ OPR_EXECUTOR_RETRY_ATTEMPTS=5
 OPR_EXECUTOR_RETRY_DELAY_MS=500
 ```
 
-> `OPR_EXECUTOR_CONNECTION_STORAGE` takes a DSN string that represents a connection to your storage device. If you would like to use your local filesystem, you can use `file://localhost`. If using S3 or any other provider for storage, use a DSN of the following format `s3://access_key:access_secret@host:port/bucket_name?region=us-east-1`
+> `OPR_EXECUTOR_CONNECTION_STORAGE` takes a DSN string that represents a connection to your storage device. If you would like to use your local filesystem, you can use `file://localhost`. If using S3 or any other provider for storage, use a DSN of the following format `s3://access_key:access_secret@host/bucket_name?region=us-east-1`. Note that a host is always required in the DSN, even when it is not used to reach the storage backend. For S3-compatible providers with a custom endpoint (MinIO, Garage, etc.), pass the URL-encoded endpoint via the `url` parameter and use any placeholder host, ex: `s3://access_key:access_secret@localhost/bucket_name?region=us-east-1&url=http%3A%2F%2Fminio%3A9000`
 
 > For backwards compatibility, executor also supports `OPR_EXECUTOR_STORAGE_*` variables as replacement for `OPR_EXECUTOR_CONNECTION_STORAGE`, as seen in [Appwrite repository](https://github.com/appwrite/appwrite/blob/1.3.8/.env#L26-L46).
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,15 @@ OPR_EXECUTOR_RETRY_ATTEMPTS=5
 OPR_EXECUTOR_RETRY_DELAY_MS=500
 ```
 
-> `OPR_EXECUTOR_CONNECTION_STORAGE` takes a DSN string that represents a connection to your storage device. If you would like to use your local filesystem, you can use `file://localhost`. If using S3 or any other provider for storage, use a DSN of the following format `s3://access_key:access_secret@host/bucket_name?region=us-east-1`. Note that a host is always required in the DSN, even when it is not used to reach the storage backend. For S3-compatible providers with a custom endpoint (MinIO, Garage, etc.), pass the URL-encoded endpoint via the `url` parameter and use any placeholder host, ex: `s3://access_key:access_secret@localhost/bucket_name?region=us-east-1&url=http%3A%2F%2Fminio%3A9000`
+> `OPR_EXECUTOR_CONNECTION_STORAGE` takes a DSN string that represents a connection to your storage device. A host is always required in the DSN, even when it is not used to reach the storage backend. For example:
+>
+> | Storage | DSN |
+> |---------|-----|
+> | Local filesystem | `file://localhost` |
+> | AWS S3 | `s3://access_key:access_secret@host/bucket_name?region=us-east-1` |
+> | S3-compatible (MinIO, Garage, etc.) | `s3://access_key:access_secret@localhost/bucket_name?region=us-east-1&url=http%3A%2F%2Fminio%3A9000` |
+>
+> For S3-compatible providers, pass the URL-encoded endpoint via the `url` parameter and use any placeholder host.
 
 > For backwards compatibility, executor also supports `OPR_EXECUTOR_STORAGE_*` variables as replacement for `OPR_EXECUTOR_CONNECTION_STORAGE`, as seen in [Appwrite repository](https://github.com/appwrite/appwrite/blob/1.3.8/.env#L26-L46).
 

--- a/README.md
+++ b/README.md
@@ -97,10 +97,10 @@ OPR_EXECUTOR_RETRY_DELAY_MS=500
 > | Storage | DSN |
 > |---------|-----|
 > | Local filesystem | `file://localhost` |
-> | AWS S3 | `s3://access_key:access_secret@host/bucket_name?region=us-east-1` |
+> | AWS S3 | `s3://access_key:access_secret@bucket_name.s3.us-east-1.amazonaws.com?region=us-east-1` |
 > | S3-compatible (MinIO, Garage, etc.) | `s3://access_key:access_secret@localhost/bucket_name?region=us-east-1&url=http%3A%2F%2Fminio%3A9000` |
 >
-> For S3-compatible providers, pass the URL-encoded endpoint via the `url` parameter and use any placeholder host.
+> When a host is provided, the executor connects to it directly using the generic S3 device. For AWS S3, use the bucket's virtual-hosted-style endpoint as the host. For S3-compatible providers, pass the URL-encoded endpoint via the `url` parameter and use any placeholder host.
 
 > For backwards compatibility, executor also supports `OPR_EXECUTOR_STORAGE_*` variables as replacement for `OPR_EXECUTOR_CONNECTION_STORAGE`, as seen in [Appwrite repository](https://github.com/appwrite/appwrite/blob/1.3.8/.env#L26-L46).
 

--- a/src/Executor/StorageFactory.php
+++ b/src/Executor/StorageFactory.php
@@ -54,10 +54,9 @@ class StorageFactory
 
         switch ($deviceType) {
             case Storage::DEVICE_S3:
-                $bucketRoot = $root;
-                if ($bucket !== '' && $bucket !== '0') {
-                    $bucketRoot = \rtrim($bucket . '/' . \ltrim($root, '/'), '/');
-                }
+                $bucketRoot = ($bucket === '' || $bucket === '0')
+                    ? $root
+                    : \rtrim($bucket . '/' . \ltrim($root, '/'), '/');
 
                 if ($url !== '' && $url !== '0') {
                     return new S3($bucketRoot, $accessKey, $accessSecret, $url, $dsnRegion, $acl);

--- a/src/Executor/StorageFactory.php
+++ b/src/Executor/StorageFactory.php
@@ -54,13 +54,18 @@ class StorageFactory
 
         switch ($deviceType) {
             case Storage::DEVICE_S3:
+                $bucketRoot = $root;
+                if ($bucket !== '' && $bucket !== '0') {
+                    $bucketRoot = \rtrim($bucket . '/' . \ltrim($root, '/'), '/');
+                }
+
                 if ($url !== '' && $url !== '0') {
-                    return new S3($root, $accessKey, $accessSecret, $url, $dsnRegion, $acl);
+                    return new S3($bucketRoot, $accessKey, $accessSecret, $url, $dsnRegion, $acl);
                 }
 
                 if ($host !== '' && $host !== '0') {
                     $host = $insecure ? 'http://' . $host : $host;
-                    return new S3(root: $root, accessKey: $accessKey, secretKey: $accessSecret, host: $host, region: $dsnRegion, acl: $acl);
+                    return new S3(root: $bucketRoot, accessKey: $accessKey, secretKey: $accessSecret, host: $host, region: $dsnRegion, acl: $acl);
                 }
 
                 return new AWS(root: $root, accessKey: $accessKey, secretKey: $accessSecret, bucket: $bucket, region: $dsnRegion, acl: $acl);

--- a/tests/unit/Executor/StorageFactoryTest.php
+++ b/tests/unit/Executor/StorageFactoryTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Executor;
+
+use OpenRuntimes\Executor\StorageFactory;
+use PHPUnit\Framework\TestCase;
+use Utopia\Storage\Device\Local;
+use Utopia\Storage\Device\S3;
+
+final class StorageFactoryTest extends TestCase
+{
+    public function testEmptyConnectionReturnsLocalDevice(): void
+    {
+        $device = StorageFactory::getDevice('/storage/builds/app-test', '');
+
+        $this->assertInstanceOf(Local::class, $device);
+        $this->assertSame('/storage/builds/app-test', $device->getRoot());
+    }
+
+    public function testNullConnectionReturnsLocalDevice(): void
+    {
+        $device = StorageFactory::getDevice('/storage/builds/app-test', null);
+
+        $this->assertInstanceOf(Local::class, $device);
+    }
+
+    public function testInvalidDsnFallsBackToLocalDevice(): void
+    {
+        // Missing host is invalid for a DSN
+        $device = StorageFactory::getDevice('/storage/builds/app-test', 's3://accessKey:secret@/mybucket?region=garage');
+
+        $this->assertInstanceOf(Local::class, $device);
+    }
+
+    public function testS3WithUrlPrependsBucketToRoot(): void
+    {
+        $dsn = 's3://accessKey:secret@localhost/mybucket?region=garage&url=' . \urlencode('http://127.0.0.1:3900');
+        $device = StorageFactory::getDevice('/storage/builds/app-test', $dsn);
+
+        $this->assertSame(S3::class, $device::class);
+        $this->assertSame('mybucket/storage/builds/app-test', $device->getRoot());
+        $this->assertSame('mybucket/storage/builds/app-test/artifact.tar.gz', $device->getPath('artifact.tar.gz'));
+    }
+
+    public function testS3WithUrlAndRootSlashUsesBucketAsRoot(): void
+    {
+        $dsn = 's3://accessKey:secret@localhost/mybucket?region=garage&url=' . \urlencode('http://127.0.0.1:3900');
+        $device = StorageFactory::getDevice('/', $dsn);
+
+        $this->assertSame(S3::class, $device::class);
+        $this->assertSame('mybucket', $device->getRoot());
+    }
+
+    public function testS3WithUrlWithoutBucketKeepsRoot(): void
+    {
+        $dsn = 's3://accessKey:secret@localhost?region=garage&url=' . \urlencode('http://127.0.0.1:3900');
+        $device = StorageFactory::getDevice('/storage/builds/app-test', $dsn);
+
+        $this->assertSame(S3::class, $device::class);
+        $this->assertSame('/storage/builds/app-test', $device->getRoot());
+    }
+
+    public function testS3WithHostPrependsBucketToRoot(): void
+    {
+        $dsn = 's3://accessKey:secret@minio/mybucket?region=us-east-1&insecure=true';
+        $device = StorageFactory::getDevice('/storage/builds/app-test', $dsn);
+
+        $this->assertSame(S3::class, $device::class);
+        $this->assertSame('mybucket/storage/builds/app-test', $device->getRoot());
+    }
+
+    public function testS3WithHostWithoutBucketKeepsRoot(): void
+    {
+        $dsn = 's3://accessKey:secret@mybucket.s3.us-east-1.amazonaws.com?region=us-east-1';
+        $device = StorageFactory::getDevice('/storage/builds/app-test', $dsn);
+
+        $this->assertSame(S3::class, $device::class);
+        $this->assertSame('/storage/builds/app-test', $device->getRoot());
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #239

When `OPR_EXECUTOR_CONNECTION_STORAGE` points to an S3-compatible backend (MinIO, Garage, etc.) via the `url=` DSN parameter or a custom `host`, `StorageFactory::getDevice()` created the generic `S3` device without prepending the bucket from the DSN path to the storage root. Since the generic `S3` device has no separate bucket parameter, requests targeted the wrong bucket/key prefix (e.g. `NoSuchBucket: Bucket not found: storage` with path-style access), causing builds to fail with `Failed to move built code to storage`.

### Changes

- `StorageFactory`: prepend the DSN bucket to the root for both the `url=` and custom `host` S3 branches, matching Appwrite's own `getDevice()` behavior. The `AWS` branch is untouched since it receives the bucket as a separate constructor argument, and setups without a bucket in the DSN path behave exactly as before.
- Added unit tests for `StorageFactory` covering local/default fallback, invalid DSN fallback, bucket prefixing for `url=` and `host` branches, and the no-bucket cases.
- README: clarified that a host is always required in the DSN (a placeholder works when `url=` is used) and documented the `url=` parameter for S3-compatible endpoints.

With the DSN from the issue, `getDevice('/storage/builds/app-test', $dsn)->getRoot()` now returns `mybucket/storage/builds/app-test` instead of `storage/builds/app-test`.

## Test plan

- [x] `composer test:unit` (20 tests, 72 assertions, all passing)
- [x] `composer format:check`
- [x] `composer analyze` (phpstan, no errors)
- [x] `composer refactor:check` (rector, no changes)

Made with [Cursor](https://cursor.com)