### PR TITLE
Update utopia-php/storage to 3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "utopia-php/dsn": "0.2.*",
     "utopia-php/http": "2.0.0-rc18@RC",
     "utopia-php/orchestration": "^0.19.2",
-    "utopia-php/storage": "^3.0",
+    "utopia-php/storage": "^3.1",
     "utopia-php/system": "0.10.*"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8f9c253f4b7330e0eff3b3921b4cb1cd",
+    "content-hash": "5f3fc9a1f7ad194ab95cc5fc4c8b7239",
     "packages": [
         {
             "name": "brick/math",
@@ -2473,16 +2473,16 @@
         },
         {
             "name": "utopia-php/storage",
-            "version": "3.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/storage.git",
-                "reference": "171746978543323c2536edacd8ad8e8d3fde401c"
+                "reference": "38bfc0c14a16a7de2a86b3331865dad1230ed739"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/storage/zipball/171746978543323c2536edacd8ad8e8d3fde401c",
-                "reference": "171746978543323c2536edacd8ad8e8d3fde401c",
+                "url": "https://api.github.com/repos/utopia-php/storage/zipball/38bfc0c14a16a7de2a86b3331865dad1230ed739",
+                "reference": "38bfc0c14a16a7de2a86b3331865dad1230ed739",
                 "shasum": ""
             },
             "require": {
@@ -2517,9 +2517,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/storage/issues",
-                "source": "https://github.com/utopia-php/storage/tree/3.0.0"
+                "source": "https://github.com/utopia-php/storage/tree/3.1.0"
             },
-            "time": "2026-07-20T13:15:54+00:00"
+            "time": "2026-07-22T15:57:57+00:00"
         },
         {
             "name": "utopia-php/system",


### PR DESCRIPTION
## What

Bumps `utopia-php/storage` from 3.0.0 to 3.1.0. Composer updates only the storage package; there are no transitive dependency changes.

Storage 3.0 was the major API migration handled in #243. Storage 3.1 keeps the APIs used by executor compatible and focuses on S3/Local reliability.

## 3.0 → 3.1

- Aborts an in-progress multipart upload when a Local or S3 transfer fails, while preserving the original error. This prevents abandoned S3 parts from remaining billable.
- Keeps S3 transfers free of an overall deadline, but adds a 60-second no-progress watchdog and TCP keepalive so stalled connections terminate instead of hanging indefinitely.
- Changes transient S3 retries from a fixed delay to exponential backoff with full jitter, reducing synchronized retries when multiple executors are throttled together.
- Makes `S3::exists()` return `false` only for genuine not-found responses. Throttling, authentication, transport, and other remote failures now remain visible.
- Preserves the real error from the metadata lookup at the start of an S3 transfer instead of converting every failure into a not-found error.
- Includes AWS request IDs in S3 errors and hardens XML decoding for repeated elements, CDATA, and external-entity safety.
- Handles Local directory-size paths without a trailing separator and rejects an empty path rather than inspecting the filesystem root.

Upstream comparison: https://github.com/utopia-php/storage/compare/3.0.0...3.1.0

## Executor impact

All remote backends created by `StorageFactory` (`S3`, AWS, DigitalOcean Spaces, Backblaze, Linode, and Wasabi) use the S3 implementation, so the reliability improvements apply consistently across executor source downloads, build artifact uploads, and storage-backed build-cache transfers.

- Failed build and cache artifact uploads now clean up started multipart uploads, avoiding orphaned parts and their storage cost.
- Source and artifact transfer failures surface more accurate causes and S3 request IDs, improving operational diagnosis.
- A transient failure during a build-cache existence check is no longer treated as a silent cache miss. It is retried, then reaches the executor cache error handler as a warning; the build still continues because cache restore/store is best-effort.
- Large active transfers can continue without an overall timeout, while a transfer with no byte movement for 60 seconds fails and follows the existing executor error path.
- The Local directory-size and S3 listing changes do not affect a current executor call path, but make the shared devices safer.

No executor source changes are required because 3.1 does not break the storage APIs used here.

## Verification

- `composer test:unit` — 20 tests, 72 assertions
- `composer analyze` — no errors
- `composer format:check` — passed
- `composer refactor:check` — clean
- `composer audit` — no security advisories
- `git diff --check` — clean

The E2E suite requires the full Docker runtime stack and is left to CI.