### PR TITLE
Update utopia-php/storage to 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "utopia-php/dsn": "0.2.*",
     "utopia-php/http": "2.0.0-rc18@RC",
     "utopia-php/orchestration": "^0.19.2",
-    "utopia-php/storage": "dev-main#ad05f341a9a62a4de73c5312f4ab6fe69f7d0051",
+    "utopia-php/storage": "^4.0",
     "utopia-php/system": "0.10.*"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "utopia-php/dsn": "0.2.*",
     "utopia-php/http": "2.0.0-rc18@RC",
     "utopia-php/orchestration": "^0.19.2",
-    "utopia-php/storage": "^3.1",
+    "utopia-php/storage": "dev-main#ad05f341a9a62a4de73c5312f4ab6fe69f7d0051",
     "utopia-php/system": "0.10.*"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5f3fc9a1f7ad194ab95cc5fc4c8b7239",
+    "content-hash": "3201d41fb62f4220b743d0303e695572",
     "packages": [
         {
             "name": "brick/math",
@@ -2473,16 +2473,16 @@
         },
         {
             "name": "utopia-php/storage",
-            "version": "3.1.0",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/storage.git",
-                "reference": "38bfc0c14a16a7de2a86b3331865dad1230ed739"
+                "reference": "ad05f341a9a62a4de73c5312f4ab6fe69f7d0051"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/storage/zipball/38bfc0c14a16a7de2a86b3331865dad1230ed739",
-                "reference": "38bfc0c14a16a7de2a86b3331865dad1230ed739",
+                "url": "https://api.github.com/repos/utopia-php/storage/zipball/ad05f341a9a62a4de73c5312f4ab6fe69f7d0051",
+                "reference": "ad05f341a9a62a4de73c5312f4ab6fe69f7d0051",
                 "shasum": ""
             },
             "require": {
@@ -2497,6 +2497,7 @@
                 "utopia-php/telemetry": "^0.4",
                 "utopia-php/validators": "0.3.*"
             },
+            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -2517,9 +2518,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/storage/issues",
-                "source": "https://github.com/utopia-php/storage/tree/3.1.0"
+                "source": "https://github.com/utopia-php/storage/tree/main"
             },
-            "time": "2026-07-22T15:57:57+00:00"
+            "time": "2026-07-23T20:37:10+00:00"
         },
         {
             "name": "utopia-php/system",
@@ -4772,7 +4773,8 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "utopia-php/http": 5
+        "utopia-php/http": 5,
+        "utopia-php/storage": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3201d41fb62f4220b743d0303e695572",
+    "content-hash": "4406170d40da27cf62b09e1728d9a6a9",
     "packages": [
         {
             "name": "brick/math",
@@ -2473,7 +2473,7 @@
         },
         {
             "name": "utopia-php/storage",
-            "version": "dev-main",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/storage.git",
@@ -2497,7 +2497,6 @@
                 "utopia-php/telemetry": "^0.4",
                 "utopia-php/validators": "0.3.*"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -2518,7 +2517,7 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/storage/issues",
-                "source": "https://github.com/utopia-php/storage/tree/main"
+                "source": "https://github.com/utopia-php/storage/tree/4.0.0"
             },
             "time": "2026-07-23T20:37:10+00:00"
         },
@@ -4773,8 +4772,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "utopia-php/http": 5,
-        "utopia-php/storage": 20
+        "utopia-php/http": 5
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/src/Executor/Runner/Docker.php
+++ b/src/Executor/Runner/Docker.php
@@ -297,7 +297,7 @@ class Docker extends Adapter
             /**
              * Copy code files from source to a temporary location on the executor
              */
-            if ($source !== '' && $source !== '0' && !$sourceDevice->transfer($source, $tmpSource, $localDevice)) {
+            if ($source !== '' && $source !== '0' && !$sourceDevice->copy($source, $tmpSource, $localDevice)) {
                 throw new \Exception('Failed to copy source code to temporary directory');
                 ;
             }
@@ -448,7 +448,7 @@ class Docker extends Adapter
                 $destinationDevice = StorageFactory::getDevice($destination, System::getEnv('OPR_EXECUTOR_CONNECTION_STORAGE'));
                 $path = $destinationDevice->getPath(\uniqid() . '.' . \pathinfo($tmpBuild, PATHINFO_EXTENSION));
 
-                if (!$localDevice->transfer($tmpBuild, $path, $destinationDevice)) {
+                if (!$localDevice->copy($tmpBuild, $path, $destinationDevice)) {
                     throw new \Exception('Failed to move built code to storage');
                 };
 
@@ -612,7 +612,7 @@ class Docker extends Adapter
             return;
         }
 
-        if (!$cacheDevice->transfer($artifact, $tmpCache . '/stores.sqfs', $localDevice)) {
+        if (!$cacheDevice->copy($artifact, $tmpCache . '/stores.sqfs', $localDevice)) {
             throw new \Exception('Failed to restore build cache artifact');
         }
     }
@@ -628,7 +628,7 @@ class Docker extends Adapter
         $cacheDevice = $this->getBuildCacheDevice();
         $destinationArtifact = $this->getBuildCacheArtifactPath($cacheDevice, $cacheKey);
 
-        if (!$localDevice->transfer($artifact, $destinationArtifact, $cacheDevice)) {
+        if (!$localDevice->copy($artifact, $destinationArtifact, $cacheDevice)) {
             throw new \Exception('Failed to store build cache artifact');
         }
     }
@@ -991,10 +991,10 @@ class Docker extends Adapter
                 if ($logDevice->exists($logFile)) {
                     if ($logDevice->getFileSize($logFile) > MAX_LOG_SIZE) {
                         $maxToRead = MAX_LOG_SIZE;
-                        $logs = $logDevice->read($logFile, 0, $maxToRead);
+                        $logs = (string) $logDevice->read($logFile, 0, $maxToRead);
                         $logs .= "\nLog file has been truncated to " . number_format(MAX_LOG_SIZE / 1048576, 2) . "MB.";
                     } else {
-                        $logs = $logDevice->read($logFile);
+                        $logs = (string) $logDevice->read($logFile);
                     }
 
                     $logDevice->delete($logFile);
@@ -1003,10 +1003,10 @@ class Docker extends Adapter
                 if ($logDevice->exists($errorFile)) {
                     if ($logDevice->getFileSize($errorFile) > MAX_LOG_SIZE) {
                         $maxToRead = MAX_LOG_SIZE;
-                        $errors = $logDevice->read($errorFile, 0, $maxToRead);
+                        $errors = (string) $logDevice->read($errorFile, 0, $maxToRead);
                         $errors .= "\nError file has been truncated to " . number_format(MAX_LOG_SIZE / 1048576, 2) . "MB.";
                     } else {
-                        $errors = $logDevice->read($errorFile);
+                        $errors = (string) $logDevice->read($errorFile);
                     }
 
                     $logDevice->delete($errorFile);


### PR DESCRIPTION
## What

Updates executor to the stable `utopia-php/storage` 4.0.0 release and migrates to its breaking streaming API:

- Replaces four cross-device `transfer()` calls with `copy()` for source downloads, build artifact uploads, and build-cache restore/store.
- Explicitly casts the four Local log/error `read()` streams to strings where executor response assembly requires strings.
- Updates the direct constraint to `^4.0` and locks storage 4.0.0; no transitive packages change.

## Storage 4.0 changes and executor impact

- Storage I/O is streams-only: `read()` returns `StreamInterface`, while `write()` and `upload()` consume streams. Source, artifact, and cache copies no longer require whole payload strings in executor memory.
- `copy()` replaces `transfer()` and centralizes bounded cross-device streaming, retaining chunked multipart upload and abort-on-failure behavior.
- S3 downloads stream into temporary storage as bytes arrive instead of buffering the complete response body in PHP memory.
- S3-family adapters require injected HTTP clients to implement both PSR-18 and the streaming client interface. Executor uses the library default client, which satisfies both interfaces, so `StorageFactory` needs no client migration.
- Same-device S3 copies can run provider-side when the adapter knows its bucket. Current executor flows copy between remote and Local devices, so their behavior remains cross-device streaming.
- Runtime log and error files still become strings at the response boundary by design; executor already caps these reads at `MAX_LOG_SIZE`.
- Multipart upload verbs are simplified (`prepareUpload`/`finalizeUpload`/`uploadData` become `prepare`/`finalize`/`upload`), but executor does not call those lower-level methods directly.

Storage release: https://github.com/utopia-php/storage/releases/tag/4.0.0

Upstream comparison: https://github.com/utopia-php/monorepo/compare/storage/3.1.0...storage/4.0.0

## Verification

Run against stable storage 4.0.0:

- `composer test:unit` — 20 tests, 72 assertions
- `composer analyze` — no errors
- `composer format:check` — passed
- `composer refactor:check` — clean
- `composer audit` — no security advisories
- `git diff --check` — clean

`composer validate --strict` reports only the existing exact-version warning for `utopia-php/http`.

The E2E suite requires the full Docker runtime stack and is left to CI.