### PR TITLE
fix(storage): address the DSN bucket through the endpoint and refuse a DSN that names no device

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,15 +92,18 @@ OPR_EXECUTOR_RETRY_ATTEMPTS=5
 OPR_EXECUTOR_RETRY_DELAY_MS=500
 ```
 
-> `OPR_EXECUTOR_CONNECTION_STORAGE` takes a DSN string that represents a connection to your storage device. A host is always required in the DSN, even when it is not used to reach the storage backend. For example:
+> `OPR_EXECUTOR_CONNECTION_STORAGE` takes a DSN string that represents a connection to your storage device. Every scheme but `file` and `local` requires a host. For example:
 >
 > | Storage | DSN |
 > |---------|-----|
 > | Local filesystem | `file://localhost` |
 > | AWS S3 | `s3://access_key:access_secret@bucket_name.s3.us-east-1.amazonaws.com?region=us-east-1` |
-> | S3-compatible (MinIO, Garage, etc.) | `s3://access_key:access_secret@localhost/bucket_name?region=us-east-1&url=http%3A%2F%2Fminio%3A9000` |
+> | S3-compatible (MinIO, Garage, etc.) | `s3://access_key:access_secret@minio:9000/bucket_name?region=us-east-1&insecure=true` |
+> | S3-compatible, endpoint given outright | `s3://access_key:access_secret@localhost/bucket_name?region=us-east-1&url=http%3A%2F%2Fminio%3A9000` |
 >
-> When a host is provided, the executor connects to it directly using the generic S3 device. For AWS S3, use the bucket's virtual-hosted-style endpoint as the host. For S3-compatible providers, pass the URL-encoded endpoint via the `url` parameter and use any placeholder host.
+> The DSN resolves to an endpoint of `scheme://host[:port][/bucket]`, and every object key hangs off it. `insecure=true` makes that scheme `http`, and the port is used as given. The bucket is the path of the DSN, and it reaches the endpoint exactly once: it is appended for path-style addressing, and left alone where the endpoint already names it, either as the leading label of the host (AWS S3, DigitalOcean Spaces, Backblaze, Linode and Wasabi all address their buckets that way) or as the path of a `url`. `url` replaces the scheme, host and port, so the last two rows above address the same object.
+>
+> A DSN that cannot be parsed, or whose scheme has no device, is rejected rather than quietly falling back to the local filesystem. Ask for local storage with `file://` or `local://`, or leave the variable empty.
 
 > For backwards compatibility, executor also supports `OPR_EXECUTOR_STORAGE_*` variables as replacement for `OPR_EXECUTOR_CONNECTION_STORAGE`, as seen in [Appwrite repository](https://github.com/appwrite/appwrite/blob/1.3.8/.env#L26-L46).
 

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "utopia-php/dsn": "0.2.*",
     "utopia-php/http": "2.0.0-rc18@RC",
     "utopia-php/orchestration": "^0.19.2",
-    "utopia-php/storage": "^4.0",
+    "utopia-php/storage": "^4.0.2",
     "utopia-php/system": "0.10.*"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4406170d40da27cf62b09e1728d9a6a9",
+    "content-hash": "71409a0d4b910f2c87877d693e733001",
     "packages": [
         {
             "name": "brick/math",
@@ -1312,16 +1312,16 @@
         },
         {
             "name": "symfony/http-client",
-            "version": "v7.4.14",
+            "version": "v7.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "f6bc6b5a54ff5afac4725cacec9bf2f52eb15920"
+                "reference": "817bb83ef06717f67ab72a3f03e3b63fbe138de1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/f6bc6b5a54ff5afac4725cacec9bf2f52eb15920",
-                "reference": "f6bc6b5a54ff5afac4725cacec9bf2f52eb15920",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/817bb83ef06717f67ab72a3f03e3b63fbe138de1",
+                "reference": "817bb83ef06717f67ab72a3f03e3b63fbe138de1",
                 "shasum": ""
             },
             "require": {
@@ -1389,7 +1389,7 @@
                 "http"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client/tree/v7.4.14"
+                "source": "https://github.com/symfony/http-client/tree/v7.4.15"
             },
             "funding": [
                 {
@@ -1409,7 +1409,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-16T11:50:14+00:00"
+            "time": "2026-07-29T07:12:33+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
@@ -1660,16 +1660,16 @@
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.38.2",
+            "version": "v1.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8"
+                "reference": "5ea99087fb99c273a9b9236ed4c31e78b16103c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/796a26abb75ce49f3a84433cd81bf1009d73d5f8",
-                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/5ea99087fb99c273a9b9236ed4c31e78b16103c6",
+                "reference": "5ea99087fb99c273a9b9236ed4c31e78b16103c6",
                 "shasum": ""
             },
             "require": {
@@ -1716,7 +1716,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.38.2"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.41.0"
             },
             "funding": [
                 {
@@ -1736,7 +1736,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-27T06:51:48+00:00"
+            "time": "2026-07-01T12:47:55+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -1879,16 +1879,16 @@
         },
         {
             "name": "utopia-php/client",
-            "version": "0.2.3",
+            "version": "0.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/client.git",
-                "reference": "377dc1f79441ac1584f25dba57904ee1cf0f626b"
+                "reference": "ee4c3429634f84c175e45f2a0c1836eaf78c2528"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/client/zipball/377dc1f79441ac1584f25dba57904ee1cf0f626b",
-                "reference": "377dc1f79441ac1584f25dba57904ee1cf0f626b",
+                "url": "https://api.github.com/repos/utopia-php/client/zipball/ee4c3429634f84c175e45f2a0c1836eaf78c2528",
+                "reference": "ee4c3429634f84c175e45f2a0c1836eaf78c2528",
                 "shasum": ""
             },
             "require": {
@@ -1896,7 +1896,7 @@
                 "psr/http-client": "^1.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.1 || ^2.0",
-                "utopia-php/pools": "^1.0",
+                "utopia-php/pools": "^2.0",
                 "utopia-php/psr7": "^0.2",
                 "utopia-php/span": "^1.1 || ^3.0 || ^4.0"
             },
@@ -1930,9 +1930,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/client/issues",
-                "source": "https://github.com/utopia-php/client/tree/0.2.3"
+                "source": "https://github.com/utopia-php/client/tree/0.3.0"
             },
-            "time": "2026-07-13T15:29:09+00:00"
+            "time": "2026-07-31T08:38:16+00:00"
         },
         {
             "name": "utopia-php/compression",
@@ -2282,21 +2282,21 @@
         },
         {
             "name": "utopia-php/pools",
-            "version": "1.1.0",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/pools.git",
-                "reference": "fd5aa7e89685ffc74f9dff3d23c270ef30c7bbf3"
+                "reference": "86d43fcacd125232c0743e8c22695faf97285cf3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/pools/zipball/fd5aa7e89685ffc74f9dff3d23c270ef30c7bbf3",
-                "reference": "fd5aa7e89685ffc74f9dff3d23c270ef30c7bbf3",
+                "url": "https://api.github.com/repos/utopia-php/pools/zipball/86d43fcacd125232c0743e8c22695faf97285cf3",
+                "reference": "86d43fcacd125232c0743e8c22695faf97285cf3",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.4",
-                "utopia-php/telemetry": "^0.4"
+                "utopia-php/telemetry": "^0.4.6"
             },
             "require-dev": {
                 "swoole/ide-helper": "6.*"
@@ -2332,9 +2332,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/pools/issues",
-                "source": "https://github.com/utopia-php/pools/tree/1.1.0"
+                "source": "https://github.com/utopia-php/pools/tree/2.0.2"
             },
-            "time": "2026-07-17T10:19:09+00:00"
+            "time": "2026-08-05T18:07:20+00:00"
         },
         {
             "name": "utopia-php/psr7",
@@ -2433,20 +2433,20 @@
         },
         {
             "name": "utopia-php/span",
-            "version": "4.0.1",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/span.git",
-                "reference": "d11f2714324cb22b286b2afbf3ea9de32c68de83"
+                "reference": "7969d920044c1e106d9eede414e2d6e8df206ff5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/span/zipball/d11f2714324cb22b286b2afbf3ea9de32c68de83",
-                "reference": "d11f2714324cb22b286b2afbf3ea9de32c68de83",
+                "url": "https://api.github.com/repos/utopia-php/span/zipball/7969d920044c1e106d9eede414e2d6e8df206ff5",
+                "reference": "7969d920044c1e106d9eede414e2d6e8df206ff5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
                 "swoole/ide-helper": "^5.0"
@@ -2467,22 +2467,22 @@
             "description": "Simple span tracing library for PHP with coroutine support",
             "support": {
                 "issues": "https://github.com/utopia-php/span/issues",
-                "source": "https://github.com/utopia-php/span/tree/4.0.1"
+                "source": "https://github.com/utopia-php/span/tree/4.1.0"
             },
-            "time": "2026-06-20T09:45:06+00:00"
+            "time": "2026-07-24T08:46:29+00:00"
         },
         {
             "name": "utopia-php/storage",
-            "version": "4.0.0",
+            "version": "4.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/storage.git",
-                "reference": "ad05f341a9a62a4de73c5312f4ab6fe69f7d0051"
+                "reference": "64a391f5dcf043458868322dfc4d402e4d154c4c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/storage/zipball/ad05f341a9a62a4de73c5312f4ab6fe69f7d0051",
-                "reference": "ad05f341a9a62a4de73c5312f4ab6fe69f7d0051",
+                "url": "https://api.github.com/repos/utopia-php/storage/zipball/64a391f5dcf043458868322dfc4d402e4d154c4c",
+                "reference": "64a391f5dcf043458868322dfc4d402e4d154c4c",
                 "shasum": ""
             },
             "require": {
@@ -2492,9 +2492,9 @@
                 "php": ">=8.5",
                 "psr/http-client": "^1.0",
                 "psr/http-message": "^1.1 || ^2.0",
-                "utopia-php/client": "0.2.*",
+                "utopia-php/client": "0.2.* || 0.3.*",
                 "utopia-php/psr7": "0.2.*",
-                "utopia-php/telemetry": "^0.4",
+                "utopia-php/telemetry": "^0.4.6",
                 "utopia-php/validators": "0.3.*"
             },
             "type": "library",
@@ -2517,9 +2517,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/storage/issues",
-                "source": "https://github.com/utopia-php/storage/tree/4.0.0"
+                "source": "https://github.com/utopia-php/storage/tree/4.0.2"
             },
-            "time": "2026-07-23T20:37:10+00:00"
+            "time": "2026-08-05T18:07:20+00:00"
         },
         {
             "name": "utopia-php/system",
@@ -2574,16 +2574,16 @@
         },
         {
             "name": "utopia-php/telemetry",
-            "version": "0.4.5",
+            "version": "0.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/telemetry.git",
-                "reference": "139943bffcd4f6dd8fb9ed247f946a1d151b006a"
+                "reference": "f96778a01792c32df0876fe1f38a79b9588445d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/telemetry/zipball/139943bffcd4f6dd8fb9ed247f946a1d151b006a",
-                "reference": "139943bffcd4f6dd8fb9ed247f946a1d151b006a",
+                "url": "https://api.github.com/repos/utopia-php/telemetry/zipball/f96778a01792c32df0876fe1f38a79b9588445d8",
+                "reference": "f96778a01792c32df0876fe1f38a79b9588445d8",
                 "shasum": ""
             },
             "require": {
@@ -2619,9 +2619,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/telemetry/issues",
-                "source": "https://github.com/utopia-php/telemetry/tree/0.4.5"
+                "source": "https://github.com/utopia-php/telemetry/tree/0.4.6"
             },
-            "time": "2026-07-08T11:07:25+00:00"
+            "time": "2026-08-05T17:56:48+00:00"
         },
         {
             "name": "utopia-php/validators",

--- a/src/Executor/StorageFactory.php
+++ b/src/Executor/StorageFactory.php
@@ -24,14 +24,17 @@ class StorageFactory
      * Get storage device by connection string
      *
      * @param string $root Root path for storage
-     * @param ?string $connection DSN connection string. An empty or null connection means no object storage is configured for this deployment and yields the local device.
+     * @param ?string $connection DSN connection string. An empty or null connection means no object storage is configured for this deployment, and a `file` or `local` scheme asks for the local device outright. Both yield the local device rooted at $root.
      * @param (ClientInterface&StreamingClientInterface)|null $client HTTP client for the remote devices, defaulting to the one utopia-php/storage builds
      *
      * @throws InvalidArgumentException When the connection string cannot be parsed or names a scheme with no device
      */
     public static function getDevice(string $root, ?string $connection = '', (ClientInterface&StreamingClientInterface)|null $client = null): Device
     {
-        if ($connection === null || $connection === '') {
+        $connection ??= '';
+        $localSchemes = ['file', DeviceType::Local->value];
+
+        if ($connection === '' || \in_array(\strtolower((string) \strstr($connection, '://', true)), $localSchemes, true)) {
             return new Local($root);
         }
 
@@ -64,24 +67,28 @@ class StorageFactory
     /**
      * Endpoint every object key hangs off, as `scheme://host[:port][/bucket]`.
      *
-     * The bucket is appended for path-style addressing and left out when the host already
-     * carries it as its leading label, which is how the branded devices address their buckets.
+     * The `url` parameter replaces the scheme, host and port it would otherwise be built from.
+     * Whether addressing is virtual-hosted or path-style is decided from the endpoint and never
+     * from the scheme: the bucket reaches the endpoint exactly once, so it is appended unless the
+     * endpoint already names it, as the leading label of the host or as the path of a `url`. The
+     * branded devices build a host whose leading label is the bucket, so that same rule holds for
+     * them once utopia-php/storage has resolved their endpoint.
      */
     private static function getEndpoint(DSN $dsn, string $bucket): string
     {
         $url = $dsn->getParam('url');
-
-        if ($url !== '') {
-            return $url;
-        }
-
-        $host = $dsn->getHost();
         $port = $dsn->getPort();
-        $endpoint = ($dsn->getParam('insecure') === 'true' ? 'http://' : 'https://')
-            . $host
-            . ($port === null || $port === '' ? '' : ':' . $port);
 
-        if ($bucket === '' || \str_starts_with($host, $bucket . '.')) {
+        $endpoint = $url === ''
+            ? ($dsn->getParam('insecure') === 'true' ? 'http://' : 'https://')
+                . $dsn->getHost()
+                . ($port === null || $port === '' ? '' : ':' . $port)
+            : \rtrim($url, '/');
+
+        $scheme = \strpos($endpoint, '://');
+        $authority = $scheme === false ? $endpoint : \substr($endpoint, $scheme + 3);
+
+        if ($bucket === '' || \str_starts_with($authority, $bucket . '.') || \str_ends_with($authority, '/' . $bucket)) {
             return $endpoint;
         }
 

--- a/src/Executor/StorageFactory.php
+++ b/src/Executor/StorageFactory.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace OpenRuntimes\Executor;
 
-use Utopia\Console;
+use InvalidArgumentException;
+use Psr\Http\Client\ClientInterface;
 use Utopia\DSN\DSN;
-use Utopia\Storage\Acl;
+use Utopia\Psr18\StreamingClientInterface;
+use Utopia\Storage\Device;
 use Utopia\Storage\Device\AWS;
 use Utopia\Storage\Device\Backblaze;
 use Utopia\Storage\Device\DOSpaces;
@@ -14,7 +16,6 @@ use Utopia\Storage\Device\Linode;
 use Utopia\Storage\Device\Local;
 use Utopia\Storage\Device\S3;
 use Utopia\Storage\Device\Wasabi;
-use Utopia\Storage\Device;
 use Utopia\Storage\DeviceType;
 
 class StorageFactory
@@ -23,67 +24,67 @@ class StorageFactory
      * Get storage device by connection string
      *
      * @param string $root Root path for storage
-     * @param ?string $connection DSN connection string. If empty or null, the local device will be used.
+     * @param ?string $connection DSN connection string. An empty or null connection means no object storage is configured for this deployment and yields the local device.
+     * @param (ClientInterface&StreamingClientInterface)|null $client HTTP client for the remote devices, defaulting to the one utopia-php/storage builds
+     *
+     * @throws InvalidArgumentException When the connection string cannot be parsed or names a scheme with no device
      */
-    public static function getDevice(string $root, ?string $connection = ''): Device
+    public static function getDevice(string $root, ?string $connection = '', (ClientInterface&StreamingClientInterface)|null $client = null): Device
     {
-        $connection ??= '';
-        $acl = Acl::Private;
-        $deviceType = DeviceType::Local->value;
-        $accessKey = '';
-        $accessSecret = '';
-        $host = '';
-        $bucket = '';
-        $dsnRegion = '';
-        $insecure = false;
-        $url = '';
+        if ($connection === null || $connection === '') {
+            return new Local($root);
+        }
 
         try {
             $dsn = new DSN($connection);
-            $deviceType = $dsn->getScheme();
-            $accessKey = $dsn->getUser() ?? '';
-            $accessSecret = $dsn->getPassword() ?? '';
-            $host = $dsn->getHost();
-            $bucket = $dsn->getPath() ?? '';
-            $dsnRegion = $dsn->getParam('region');
-            $insecure = $dsn->getParam('insecure', 'false') === 'true';
-            $url = $dsn->getParam('url', '');
-
         } catch (\Throwable $throwable) {
-            Console::warning($throwable->getMessage() . ' - Invalid DSN. Defaulting to Local device.');
+            throw new InvalidArgumentException('Unable to parse storage DSN: ' . $throwable->getMessage(), previous: $throwable);
         }
 
-        switch (DeviceType::tryFrom($deviceType)) {
-            case DeviceType::S3:
-                $bucketRoot = ($bucket === '' || $bucket === '0')
-                    ? $root
-                    : \rtrim($bucket . '/' . \ltrim($root, '/'), '/');
+        $scheme = $dsn->getScheme();
+        $deviceType = DeviceType::tryFrom($scheme)
+            ?? throw new InvalidArgumentException(sprintf("Storage DSN scheme '%s' has no device", $scheme));
 
-                if ($url !== '' && $url !== '0') {
-                    return new S3($bucketRoot, $accessKey, $accessSecret, $url, $dsnRegion, $acl);
-                }
+        $accessKey = $dsn->getUser() ?? '';
+        $secretKey = $dsn->getPassword() ?? '';
+        $bucket = $dsn->getPath() ?? '';
+        $region = $dsn->getParam('region');
 
-                if ($host !== '' && $host !== '0') {
-                    $host = $insecure ? 'http://' . $host : $host;
-                    return new S3(root: $bucketRoot, accessKey: $accessKey, secretKey: $accessSecret, host: $host, region: $dsnRegion, acl: $acl);
-                }
+        return match ($deviceType) {
+            DeviceType::Local => new Local($root),
+            DeviceType::S3 => new S3($root, $accessKey, $secretKey, self::getEndpoint($dsn, $bucket), $region, client: $client),
+            DeviceType::AwsS3 => new AWS($root, $accessKey, $secretKey, $bucket, $region, client: $client),
+            DeviceType::DoSpaces => new DOSpaces($root, $accessKey, $secretKey, $bucket, $region, client: $client),
+            DeviceType::Backblaze => new Backblaze($root, $accessKey, $secretKey, $bucket, $region, client: $client),
+            DeviceType::Linode => new Linode($root, $accessKey, $secretKey, $bucket, $region, client: $client),
+            DeviceType::Wasabi => new Wasabi($root, $accessKey, $secretKey, $bucket, $region, client: $client),
+        };
+    }
 
-                return new AWS(root: $root, accessKey: $accessKey, secretKey: $accessSecret, bucket: $bucket, region: $dsnRegion, acl: $acl);
+    /**
+     * Endpoint every object key hangs off, as `scheme://host[:port][/bucket]`.
+     *
+     * The bucket is appended for path-style addressing and left out when the host already
+     * carries it as its leading label, which is how the branded devices address their buckets.
+     */
+    private static function getEndpoint(DSN $dsn, string $bucket): string
+    {
+        $url = $dsn->getParam('url');
 
-            case DeviceType::DoSpaces:
-                return new DOSpaces($root, $accessKey, $accessSecret, $bucket, $dsnRegion, $acl);
-
-            case DeviceType::Backblaze:
-                return new Backblaze($root, $accessKey, $accessSecret, $bucket, $dsnRegion, $acl);
-
-            case DeviceType::Linode:
-                return new Linode($root, $accessKey, $accessSecret, $bucket, $dsnRegion, $acl);
-
-            case DeviceType::Wasabi:
-                return new Wasabi($root, $accessKey, $accessSecret, $bucket, $dsnRegion, $acl);
-
-            default:
-                return new Local($root);
+        if ($url !== '') {
+            return $url;
         }
+
+        $host = $dsn->getHost();
+        $port = $dsn->getPort();
+        $endpoint = ($dsn->getParam('insecure') === 'true' ? 'http://' : 'https://')
+            . $host
+            . ($port === null || $port === '' ? '' : ':' . $port);
+
+        if ($bucket === '' || \str_starts_with($host, $bucket . '.')) {
+            return $endpoint;
+        }
+
+        return $endpoint . '/' . $bucket;
     }
 }

--- a/tests/unit/Executor/StorageFactoryTest.php
+++ b/tests/unit/Executor/StorageFactoryTest.php
@@ -56,6 +56,11 @@ final class StorageFactoryTest extends TestCase
             self::OBJECT_KEY,
             'http://minio.edge.svc.cluster.local/storage/wal-archive/db-abc/000000010000000000000001',
         ];
+        yield 'no bucket leaves the key to name it' => [
+            's3://user:password@minio.edge.svc.cluster.local?insecure=true',
+            self::OBJECT_KEY,
+            'http://minio.edge.svc.cluster.local/wal-archive/db-abc/000000010000000000000001',
+        ];
     }
 
     #[DataProvider('connections')]

--- a/tests/unit/Executor/StorageFactoryTest.php
+++ b/tests/unit/Executor/StorageFactoryTest.php
@@ -46,8 +46,13 @@ final class StorageFactoryTest extends TestCase
             self::OBJECT_KEY,
             'https://mybucket.s3.us-east-1.amazonaws.com/wal-archive/db-abc/000000010000000000000001',
         ];
-        yield 'explicit url wins' => [
+        yield 'explicit url carrying the bucket' => [
             's3://key:secret@localhost/mybucket?region=garage&url=' . \urlencode('http://127.0.0.1:3900/mybucket'),
+            self::OBJECT_KEY,
+            'http://127.0.0.1:3900/mybucket/wal-archive/db-abc/000000010000000000000001',
+        ];
+        yield 'explicit url without the bucket resolves the same' => [
+            's3://key:secret@localhost/mybucket?region=garage&url=' . \urlencode('http://127.0.0.1:3900'),
             self::OBJECT_KEY,
             'http://127.0.0.1:3900/mybucket/wal-archive/db-abc/000000010000000000000001',
         ];
@@ -60,6 +65,11 @@ final class StorageFactoryTest extends TestCase
             's3://user:password@minio.edge.svc.cluster.local?insecure=true',
             self::OBJECT_KEY,
             'http://minio.edge.svc.cluster.local/wal-archive/db-abc/000000010000000000000001',
+        ];
+        yield 'a bucket named zero is a bucket' => [
+            's3://user:password@minio.edge.svc.cluster.local/0?insecure=true',
+            self::OBJECT_KEY,
+            'http://minio.edge.svc.cluster.local/0/wal-archive/db-abc/000000010000000000000001',
         ];
     }
 
@@ -197,10 +207,13 @@ final class StorageFactoryTest extends TestCase
     {
         yield 'empty' => [''];
         yield 'null' => [null];
+        yield 'documented file scheme' => ['file://localhost'];
+        yield 'file scheme with no host' => ['file:///tmp'];
+        yield 'local scheme' => ['local://localhost'];
     }
 
     #[DataProvider('unconfiguredConnections')]
-    public function testUnconfiguredConnectionResolvesToLocalDevice(?string $connection): void
+    public function testConnectionWithoutObjectStorageResolvesToLocalDevice(?string $connection): void
     {
         $device = StorageFactory::getDevice('/storage/builds/app-test', $connection);
 

--- a/tests/unit/Executor/StorageFactoryTest.php
+++ b/tests/unit/Executor/StorageFactoryTest.php
@@ -4,79 +4,230 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Executor;
 
+use InvalidArgumentException;
 use OpenRuntimes\Executor\StorageFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Utopia\Psr18\StreamingClientInterface;
+use Utopia\Psr7\Response;
+use Utopia\Psr7\Stream;
+use Utopia\Storage\Device;
 use Utopia\Storage\Device\Local;
-use Utopia\Storage\Device\S3;
 
 final class StorageFactoryTest extends TestCase
 {
-    public function testEmptyConnectionReturnsLocalDevice(): void
+    private const string OBJECT_KEY = 'wal-archive/db-abc/000000010000000000000001';
+
+    /**
+     * @return \Iterator<string, array{string, string, string}>
+     */
+    public static function connections(): \Iterator
     {
-        $device = StorageFactory::getDevice('/storage/builds/app-test', '');
+        yield 'path-style with a port' => [
+            's3://key:secret@host.internal:30000/storage?insecure=true',
+            self::OBJECT_KEY,
+            'http://host.internal:30000/storage/wal-archive/db-abc/000000010000000000000001',
+        ];
+        yield 'path-style without a port' => [
+            's3://key:secret@s3.amazonaws.com/backups?region=us-east-1',
+            self::OBJECT_KEY,
+            'https://s3.amazonaws.com/backups/wal-archive/db-abc/000000010000000000000001',
+        ];
+        yield 'virtual-hosted dospaces' => [
+            'dospaces://key:secret@fra1.digitaloceanspaces.com/appwrite-backups?region=fra1',
+            self::OBJECT_KEY,
+            'https://appwrite-backups.fra1.digitaloceanspaces.com/wal-archive/db-abc/000000010000000000000001',
+        ];
+        yield 'virtual-hosted s3 does not repeat the bucket' => [
+            's3://key:secret@mybucket.s3.us-east-1.amazonaws.com/mybucket?region=us-east-1',
+            self::OBJECT_KEY,
+            'https://mybucket.s3.us-east-1.amazonaws.com/wal-archive/db-abc/000000010000000000000001',
+        ];
+        yield 'explicit url wins' => [
+            's3://key:secret@localhost/mybucket?region=garage&url=' . \urlencode('http://127.0.0.1:3900/mybucket'),
+            self::OBJECT_KEY,
+            'http://127.0.0.1:3900/mybucket/wal-archive/db-abc/000000010000000000000001',
+        ];
+        yield 'deployed minio connection' => [
+            's3://user:password@minio.edge.svc.cluster.local/storage?insecure=true',
+            self::OBJECT_KEY,
+            'http://minio.edge.svc.cluster.local/storage/wal-archive/db-abc/000000010000000000000001',
+        ];
+    }
+
+    #[DataProvider('connections')]
+    public function testConnectionResolvesToObjectUrl(string $connection, string $objectKey, string $url): void
+    {
+        $client = new class () implements ClientInterface, StreamingClientInterface {
+            public string $url = '';
+
+            public function sendRequest(RequestInterface $request): ResponseInterface
+            {
+                $this->url = (string) $request->getUri();
+
+                return new Response(200);
+            }
+
+            public function stream(RequestInterface $request, callable $sink): ResponseInterface
+            {
+                return $this->sendRequest($request);
+            }
+        };
+
+        StorageFactory::getDevice('/', $connection, $client)
+            ->write($objectKey, new Stream('wal'), 'application/octet-stream');
+
+        $this->assertSame($url, $client->url);
+    }
+
+    public function testRootedDeviceAddressesTheSameObjectThroughGetPath(): void
+    {
+        $client = new class () implements ClientInterface, StreamingClientInterface {
+            public string $url = '';
+
+            public function sendRequest(RequestInterface $request): ResponseInterface
+            {
+                $this->url = (string) $request->getUri();
+
+                return new Response(200);
+            }
+
+            public function stream(RequestInterface $request, callable $sink): ResponseInterface
+            {
+                return $this->sendRequest($request);
+            }
+        };
+
+        $device = StorageFactory::getDevice('/build-cache', 's3://user:password@minio.edge.svc.cluster.local/storage?insecure=true', $client);
+        $device->write($device->getPath('cache-key/lz4-b1M/stores.sqfs'), new Stream('artifact'), 'application/octet-stream');
+
+        $this->assertSame(
+            'http://minio.edge.svc.cluster.local/storage/build-cache/cache-key/lz4-b1M/stores.sqfs',
+            $client->url
+        );
+    }
+
+    public function testPathStyleConnectionPutsBucketAndPortOnTheWire(): void
+    {
+        $server = \stream_socket_server('tcp://127.0.0.1:0', $errorCode, $errorMessage);
+        $this->assertNotFalse($server, 'Unable to bind a local listener: ' . $errorMessage);
+
+        $address = (string) \stream_socket_get_name($server, false);
+        $port = (int) \substr($address, \strrpos($address, ':') + 1);
+
+        $script = <<<'PHP'
+        require $argv[1];
+        \OpenRuntimes\Executor\StorageFactory::getDevice('/', $argv[2])
+            ->write($argv[3], new \Utopia\Psr7\Stream('wal'), 'application/octet-stream');
+        PHP;
+
+        $process = \proc_open(
+            [
+                PHP_BINARY,
+                '-r',
+                $script,
+                \dirname(__DIR__, 3) . '/vendor/autoload.php',
+                sprintf('s3://key:secret@127.0.0.1:%d/backups?region=fra&insecure=true', $port),
+                self::OBJECT_KEY,
+            ],
+            [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes
+        );
+        $this->assertNotFalse($process, 'Unable to start the writer process');
+
+        $connection = \stream_socket_accept($server, 30);
+        $this->assertNotFalse($connection, 'The device never connected to the endpoint the DSN names');
+
+        $head = '';
+        while (!\str_contains($head, "\r\n\r\n")) {
+            $chunk = \fread($connection, 4096);
+            if ($chunk === false || $chunk === '') {
+                break;
+            }
+
+            $head .= $chunk;
+        }
+
+        \fwrite($connection, "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+        \fclose($connection);
+        \fclose($server);
+        foreach ($pipes as $pipe) {
+            \fclose($pipe);
+        }
+
+        \proc_terminate($process);
+        \proc_close($process);
+
+        $this->assertStringStartsWith('PUT /backups/' . self::OBJECT_KEY . " HTTP/1.1\r\n", $head);
+        $this->assertStringContainsString("\r\nhost: 127.0.0.1:{$port}\r\n", \strtolower($head));
+    }
+
+    /**
+     * @return \Iterator<string, array{string}>
+     */
+    public static function unusableConnections(): \Iterator
+    {
+        yield 'no host' => ['s3://accessKey:secret@/mybucket?region=garage'];
+        yield 'no scheme' => ['accessKey:secret@minio/mybucket'];
+        yield 'unparseable' => ['s3://accessKey:secret@minio:port/mybucket'];
+        yield 'unknown scheme' => ['ftp://accessKey:secret@minio/mybucket'];
+        yield 'misspelled scheme' => ['s3x://accessKey:secret@minio/mybucket'];
+    }
+
+    #[DataProvider('unusableConnections')]
+    public function testUnusableConnectionIsRefused(string $connection): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        StorageFactory::getDevice('/storage/builds/app-test', $connection);
+    }
+
+    /**
+     * @return \Iterator<string, array{(string | null)}>
+     */
+    public static function unconfiguredConnections(): \Iterator
+    {
+        yield 'empty' => [''];
+        yield 'null' => [null];
+    }
+
+    #[DataProvider('unconfiguredConnections')]
+    public function testUnconfiguredConnectionResolvesToLocalDevice(?string $connection): void
+    {
+        $device = StorageFactory::getDevice('/storage/builds/app-test', $connection);
 
         $this->assertInstanceOf(Local::class, $device);
         $this->assertSame('/storage/builds/app-test', $device->getRoot());
     }
 
-    public function testNullConnectionReturnsLocalDevice(): void
+    public function testRootIsNotRewrittenByTheBucket(): void
     {
-        $device = StorageFactory::getDevice('/storage/builds/app-test', null);
+        $device = StorageFactory::getDevice('/storage/builds/app-test', 's3://accessKey:secret@minio/mybucket?region=us-east-1&insecure=true');
 
-        $this->assertInstanceOf(Local::class, $device);
-    }
-
-    public function testInvalidDsnFallsBackToLocalDevice(): void
-    {
-        // Missing host is invalid for a DSN
-        $device = StorageFactory::getDevice('/storage/builds/app-test', 's3://accessKey:secret@/mybucket?region=garage');
-
-        $this->assertInstanceOf(Local::class, $device);
-    }
-
-    public function testS3WithUrlPrependsBucketToRoot(): void
-    {
-        $dsn = 's3://accessKey:secret@localhost/mybucket?region=garage&url=' . \urlencode('http://127.0.0.1:3900');
-        $device = StorageFactory::getDevice('/storage/builds/app-test', $dsn);
-
-        $this->assertSame(S3::class, $device::class);
-        $this->assertSame('mybucket/storage/builds/app-test', $device->getRoot());
-        $this->assertSame('mybucket/storage/builds/app-test/artifact.tar.gz', $device->getPath('artifact.tar.gz'));
-    }
-
-    public function testS3WithUrlAndRootSlashUsesBucketAsRoot(): void
-    {
-        $dsn = 's3://accessKey:secret@localhost/mybucket?region=garage&url=' . \urlencode('http://127.0.0.1:3900');
-        $device = StorageFactory::getDevice('/', $dsn);
-
-        $this->assertSame(S3::class, $device::class);
-        $this->assertSame('mybucket', $device->getRoot());
-    }
-
-    public function testS3WithUrlWithoutBucketKeepsRoot(): void
-    {
-        $dsn = 's3://accessKey:secret@localhost?region=garage&url=' . \urlencode('http://127.0.0.1:3900');
-        $device = StorageFactory::getDevice('/storage/builds/app-test', $dsn);
-
-        $this->assertSame(S3::class, $device::class);
         $this->assertSame('/storage/builds/app-test', $device->getRoot());
+        $this->assertSame('/storage/builds/app-test/artifact.tar.gz', $device->getPath('artifact.tar.gz'));
     }
 
-    public function testS3WithHostPrependsBucketToRoot(): void
+    public function testDeviceTypeFollowsTheScheme(): void
     {
-        $dsn = 's3://accessKey:secret@minio/mybucket?region=us-east-1&insecure=true';
-        $device = StorageFactory::getDevice('/storage/builds/app-test', $dsn);
+        $devices = [
+            's3' => 's3://key:secret@minio/mybucket?region=fra&insecure=true',
+            'awss3' => 'awss3://key:secret@s3.amazonaws.com/mybucket?region=us-east-1',
+            'dospaces' => 'dospaces://key:secret@fra1.digitaloceanspaces.com/mybucket?region=fra1',
+            'backblaze' => 'backblaze://key:secret@backblazeb2.com/mybucket?region=us-west-004',
+            'linode' => 'linode://key:secret@linodeobjects.com/mybucket?region=eu-central-1',
+            'wasabi' => 'wasabi://key:secret@wasabisys.com/mybucket?region=eu-central-1',
+            'local' => 'local://localhost/storage',
+        ];
 
-        $this->assertSame(S3::class, $device::class);
-        $this->assertSame('mybucket/storage/builds/app-test', $device->getRoot());
-    }
+        foreach ($devices as $type => $connection) {
+            $device = StorageFactory::getDevice('/', $connection);
 
-    public function testS3WithHostWithoutBucketKeepsRoot(): void
-    {
-        $dsn = 's3://accessKey:secret@mybucket.s3.us-east-1.amazonaws.com?region=us-east-1';
-        $device = StorageFactory::getDevice('/storage/builds/app-test', $dsn);
-
-        $this->assertSame(S3::class, $device::class);
-        $this->assertSame('/storage/builds/app-test', $device->getRoot());
+            $this->assertInstanceOf(Device::class, $device);
+            $this->assertSame($type, $device->getType()->value, sprintf("Scheme '%s' resolved to the wrong device", $type));
+        }
     }
 }


### PR DESCRIPTION
Fixes two defects in `OpenRuntimes\Executor\StorageFactory` found while porting the WAL shipper to Rust: [DAT-2206](https://linear.app/appwrite/issue/DAT-2206) and [DAT-2205](https://linear.app/appwrite/issue/DAT-2205).

## DAT-2206: a DSN that names no device silently became a Local device

`getDevice()` caught every parse failure, logged a warning and fell through to `default: return new Local($root)`. So an unparseable DSN, or any scheme outside `s3`/`dospaces`/`backblaze`/`linode`/`wasabi` (including `awss3`, which `DeviceType` defines), produced a Local device rooted at `/`. Every caller then wrote inside its own container and reported success: the WAL shipper "shipped" segments to its own ephemeral filesystem and published a heartbeat next to them, backup Jobs wrote dumps into their own container, and the health check that reads the archive built the same Local device and answered from the controller's filesystem. Full green, nothing durable.

`getDevice()` now throws `InvalidArgumentException` for both cases, and the scheme is resolved through an exhaustive `match` over `DeviceType`, so a device added upstream cannot silently fall back to Local again.

An **empty or null connection keeps its meaning**: "no object storage is configured for this deployment". It short-circuits to `Local` before any parsing. Callers that depend on it (`_EDGE_CONNECTIONS_BACKUPS_STORAGE` unset, `OPR_EXECUTOR_CONNECTION_STORAGE` unset) are unaffected.

## DAT-2205: the port was dropped and the bucket never reached a request

`getDevice()` read `$dsn->getHost()` and never `$dsn->getPort()`, so the shape the edge README documents, `s3://user:password@host.docker.internal:30000/storage?insecure=true`, resolved to `http://host.docker.internal` on port 80.

The bucket was folded into the device **root** (#242). That reaches a request only through `getPath()`. `S3::write()`, `read()`, `exists()`/`getInfo()` and `delete()` build their URI from the object path alone, so a caller that passes a whole object key, which is what every backup and WAL caller does, addressed the store with no bucket anywhere and landed in whatever bucket the first segment of the key happened to name.

`utopia-php/storage` 4.0.2 (utopia-php/storage#107) parses the endpoint URL, keeps its port and path, and signs that path in the SigV4 canonical request. The bucket therefore belongs in the endpoint, where it reaches every request whichever method builds the URI:

- endpoint = `(insecure ? http : https)://host[:port]`
- path-style: object URL = `{endpoint}/{bucket}/{objectKey}`
- virtual-hosted (bucket already the leading label of the host, as with `dospaces://`): object URL = `{endpoint}/{objectKey}`, bucket not repeated
- an explicit `?url=` keeps its current meaning and wins

The root is left alone, so a caller that goes through `getPath()` resolves to exactly the object it did before: the bucket moved from the front of the root to the end of the endpoint, and the concatenation is unchanged.

This raises the `utopia-php/storage` floor to `^4.0.2`. On 4.0.0 an endpoint path is neither signed nor stripped from the `Host` header, so the fix silently produces `SignatureDoesNotMatch`.

## Resolved URLs, before and after

Object key `wal-archive/db-abc/000000010000000000000001` in every row. "Before" values were read off the reverted implementation, not predicted.

| DSN | Before | After |
|---|---|---|
| `s3://key:secret@host.internal:30000/storage?insecure=true` | `http://host.internal/wal-archive/db-abc/0000…01` | `http://host.internal:30000/storage/wal-archive/db-abc/0000…01` |
| `s3://key:secret@s3.amazonaws.com/backups?region=us-east-1` | `https://s3.amazonaws.com/wal-archive/db-abc/0000…01` | `https://s3.amazonaws.com/backups/wal-archive/db-abc/0000…01` |
| `dospaces://key:secret@fra1.digitaloceanspaces.com/appwrite-backups?region=fra1` | `https://appwrite-backups.fra1.digitaloceanspaces.com/wal-archive/db-abc/0000…01` | **unchanged** |
| `s3://key:secret@mybucket.s3.us-east-1.amazonaws.com/mybucket?region=us-east-1` | `https://mybucket.s3.us-east-1.amazonaws.com/wal-archive/db-abc/0000…01` | **unchanged** |
| `s3://…?url=http://127.0.0.1:3900/mybucket` | `http://127.0.0.1:3900/mybucket/wal-archive/db-abc/0000…01` | **unchanged** |
| `getDevice('/build-cache', 's3://…@minio…/storage?insecure=true')->getPath(…)` | `http://minio…/storage/build-cache/cache-key/lz4-b1M/stores.sqfs` | **unchanged** |
| `s3://user:password@minio.edge.svc.cluster.local/storage?insecure=true` | `http://minio…/wal-archive/db-abc/0000…01` | `http://minio…/storage/wal-archive/db-abc/0000…01` |

Production (`dospaces://`) is byte-identical, as is every path that goes through `getPath()`, which covers the executor's build cache and edge's static-site reader.

**The last row does change.** The local and CI MinIO connection names bucket `storage`, and today that bucket is dropped: the object key's leading segment (`wal-archive/`, `backups/`) is what MinIO takes as the bucket, which is why the local chart creates all three. After this change those objects live under bucket `storage`, at the same keys. Both buckets are created by the chart and the clusters are rebuilt per run, so nothing is stranded, but it means **the controller, the backup/restore Jobs and the WAL shipper have to be upgraded together**, exactly as DAT-2205 requires. Worth noting that today's split is already incoherent in that deployment: `Storage::upload()` writes at `{endpoint}/{key}` while the static-site reader goes through `getPath()` and reads at `{endpoint}/storage/{key}`. This change converges them.

## Why not make `S3` honour its root instead

DAT-2205 offers that alternative. It is the wrong place. `Device::getPath()` is defined as `root . '/' . filename` and callers pass its result straight into `write()`; if `write()` also applied the root, every existing consumer (server-ce, cloud, edge, this repo's build cache) would double it. Fixing it in `utopia-php/storage` therefore means a major version and a coordinated upgrade of four repositories, to reach a place where root and bucket are still conflated. The endpoint already models "the thing every object key hangs off", 4.0.2 signs it correctly, and no change outside this repository is needed.

## Tests

`tests/unit/Executor/StorageFactoryTest.php`:

- `testConnectionResolvesToObjectUrl` pins the exact object URL for all seven DSNs in the table above, by driving the real device through a recording PSR-18 client (the seam `S3` already takes) and asserting the URI of the request it hands over. The Rust shipper carries the mirror of this table.
- `testPathStyleConnectionPutsBucketAndPortOnTheWire` binds a local listener, has a child process write through a real cURL client, and asserts the request line and `Host` header off the socket. It proves the recording client is not flattering the code, and that the SigV4 signature covers the bucket path.
- `testRootedDeviceAddressesTheSameObjectThroughGetPath` pins the build-cache round trip that must not move.
- `testUnusableConnectionIsRefused` covers no host, no scheme, unparseable, unknown scheme, misspelled scheme.
- `testUnconfiguredConnectionResolvesToLocalDevice` pins the deliberate empty-DSN meaning.
- `testDeviceTypeFollowsTheScheme` walks every `DeviceType`, and catches `awss3` resolving to Local.

Seen red: reverted `StorageFactory` to its `main` implementation, keeping only the client parameter so the doubled client still reaches the device, and confirmed 11 of the 17 failed with the "Before" URLs above. The 6 that stayed green are the byte-identical rows, which is the intended result.

`composer test:unit` (29 tests, 94 assertions), `composer format:check`, `composer analyze`, `composer refactor:check` all pass.


## What a deployment has to do about it

Any deployed `s3://` DSN whose path names a bucket starts addressing a different object, because that is the defect. Two consumers of this factory are in that position, and both are the same in-cluster MinIO connection:

- `_EDGE_CONNECTIONS_BACKUPS_STORAGE` = `s3://…@minio…/storage?insecure=true`, keys `wal-archive/{id}/…` and `backups/{id}/…`, so the bucket is `wal-archive` / `backups` today and becomes `storage` with those as key prefixes.
- `_EDGE_CONNECTIONS_STORAGE` / `_APP_CONNECTIONS_STORAGE` = `fra=s3://…@minio…/storage?insecure=true`, keys `/storage/functions/…` and `/storage/builds/…`, so the bucket is `storage` today and stays `storage` with `storage/` added to the key.

A deployment that wants today's addressing back does not need the objects moved. **Drop the bucket from the DSN path.** `s3://user:password@minio.edge.svc.cluster.local?insecure=true` resolves to a bare endpoint, the object key's leading segment keeps naming the bucket exactly as it does now, and every existing object stays where it is. That is covered by the `path-style without a port` and `virtual-hosted` rows above: a DSN with no bucket in its path is untouched by this change.

So the migration is per deployment and opt in: keep the bucket in the DSN and the bucket reaches the request (and the objects move once), or take it out and nothing changes. `dospaces://` needs neither.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
