### PR TITLE
fix(test): align testRestartPolicy with the runtime's exit() contract

### DIFF
--- a/tests/e2e/ExecutorTest.php
+++ b/tests/e2e/ExecutorTest.php
@@ -797,7 +797,11 @@ class ExecutorTest extends TestCase
             'runtimeEntrypoint' => 'cp /tmp/code.tar.gz /mnt/code/code.tar.gz && nohup helpers/start.sh "' . $command . '"',
             'restartPolicy' => 'always'
         ]);
-        $this->assertEquals(500, $response['headers']['status-code']);
+        // The runtime reports the function's exit() as a failed execution, so the
+        // executor call itself succeeds and carries statusCode 500. The server
+        // process still dies afterwards, which is what the restart count asserts.
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertEquals(500, $response['body']['statusCode']);
 
         \sleep(5);
 
@@ -807,7 +811,8 @@ class ExecutorTest extends TestCase
             'image' => 'openruntimes/php:v5-8.1',
             'runtimeEntrypoint' => 'cp /tmp/code.tar.gz /mnt/code/code.tar.gz && nohup helpers/start.sh "' . $command . '"'
         ]);
-        $this->assertEquals(500, $response['headers']['status-code']);
+        $this->assertEquals(200, $response['headers']['status-code']);
+        $this->assertEquals(500, $response['body']['statusCode']);
 
         \sleep(5);
 


### PR DESCRIPTION
## Problem

`main` is currently red. `testRestartPolicy` fails deterministically:

```
1) Tests\E2E\ExecutorTest::testRestartPolicy
Failed asserting that 200 matches expected 500.
```

Nothing in this repo changed. `openruntimes/php:v5-8.1` was re-pushed to Docker Hub on 2026-08-19 at 08:47 UTC, and `.env` pins mutable runtime tags, so CI picked up the rebuild.

## Cause

The php runtime source in `open-runtimes/runtimes` is untouched — the rebuild pulled in a newer Swoole, where a function calling `exit()` raises `Swoole\ExitException` instead of tearing down the worker mid-response. The runtime now catches it and reports a failed execution. Probing the executor directly:

```
statusCode: 500
errors: Uncaught Swoole\ExitException: swoole exit in /usr/local/server/src/function/index.php:4
```

So `exit(1)` is now a clean failed execution — executor HTTP **200** with `body.statusCode` **500** — where it previously dropped the connection and surfaced an executor-level 500.

`RestartCount=1` confirms the server process still dies afterwards, so the restart policy itself is unaffected and the `assertSame(3, $occurances)` assertion still holds. Only the two HTTP status expectations were stale.

## Verification

- Reproduced locally by pulling the new image; byte-identical to CI.
- Confirmed present on clean `origin/main`, so it is independent of any open PR.
- Full e2e suite on this branch: 39 tests, `testRestartPolicy` green, including everything past test 16 that CI never reached (`stopOnFailure` was aborting earlier).
- `format:check`, `analyze`, `refactor:check` all pass.

## Note for reviewers

Two things worth a maintainer's judgment, both out of scope here:

1. Please confirm the new `exit()` semantics are **intended** before we codify them in a test. Graceful 500-with-error reads like an improvement over a dropped connection, but it arrived via a base-image rebuild rather than a deliberate change upstream.
2. `.env` pins mutable tags (`openruntimes/php:v5-8.1`), so CI inherits upstream rebuilds like this one. Pinning digests would stop this class of surprise.

Also related: #248 was failing on `testBuildKeysFlutter` for a separate reason (the maintenance sweep reaping in-flight builds). That is fixed on that branch; this test was simply the next failure `stopOnFailure` had been hiding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)