### PR TITLE
Declare OPEN_RUNTIMES_CODE_PATH on runtime containers

### DIFF
--- a/src/Executor/Runner/Docker.php
+++ b/src/Executor/Runner/Docker.php
@@ -283,6 +283,12 @@ class Docker extends Adapter
             $sourceFile = "code.tar";
         }
 
+        // The source dir is mounted at /tmp inside the runtime, so this is
+        // where the start helper (extract.sh) finds the archive.
+        if ($source !== '' && $source !== '0' && $version !== 'v2') {
+            $variables['OPEN_RUNTIMES_CODE_PATH'] = '/tmp/' . $sourceFile;
+        }
+
         $tmpFolder = sprintf('tmp/%s/', $runtimeName);
         $tmpSource = sprintf('/%ssrc/%s', $tmpFolder, $sourceFile);
         $tmpBuild = sprintf('/%sbuilds/%s', $tmpFolder, $buildFile);

--- a/src/Executor/Runner/Docker.php
+++ b/src/Executor/Runner/Docker.php
@@ -278,9 +278,12 @@ class Docker extends Adapter
          */
         $buildFile = "code.tar.gz";
 
-        $sourceFile = "code.tar.gz";
-        if ($source !== '' && $source !== '0' && \pathinfo($source, PATHINFO_EXTENSION) === 'tar') {
-            $sourceFile = "code.tar";
+        // Keep the source's extension so the archive keeps its identity
+        // inside the runtime (code.tar.gz, code.tar, code.sqfs, ...).
+        $sourceFile = 'code.tar.gz';
+        $sourceExtension = \strpos(\basename($source), '.');
+        if ($source !== '' && $source !== '0' && $sourceExtension !== false) {
+            $sourceFile = 'code' . \substr(\basename($source), $sourceExtension);
         }
 
         // The source dir is mounted at /tmp inside the runtime, so this is

--- a/src/Executor/Runner/Docker.php
+++ b/src/Executor/Runner/Docker.php
@@ -279,11 +279,16 @@ class Docker extends Adapter
         $buildFile = "code.tar.gz";
 
         // Keep the source's extension so the archive keeps its identity
-        // inside the runtime (code.tar.gz, code.tar, code.sqfs, ...).
+        // inside the runtime (code.tar.gz, code.tar, code.sqfs, ...). Build
+        // artifacts are stored as <uniqid>.gz — pathinfo() below drops the
+        // .tar — so a bare .gz still means a gzipped tar named code.tar.gz.
         $sourceFile = 'code.tar.gz';
         $sourceExtension = \strpos(\basename($source), '.');
         if ($source !== '' && $source !== '0' && $sourceExtension !== false) {
-            $sourceFile = 'code' . \substr(\basename($source), $sourceExtension);
+            $extension = \substr(\basename($source), $sourceExtension);
+            if ($extension !== '.gz') {
+                $sourceFile = 'code' . $extension;
+            }
         }
 
         // The source dir is mounted at /tmp inside the runtime, so this is

--- a/src/Executor/Runner/Docker.php
+++ b/src/Executor/Runner/Docker.php
@@ -278,18 +278,16 @@ class Docker extends Adapter
          */
         $buildFile = "code.tar.gz";
 
-        // Keep the source's extension so the archive keeps its identity
-        // inside the runtime (code.tar.gz, code.tar, code.sqfs, ...). Build
-        // artifacts are stored as <uniqid>.gz — pathinfo() below drops the
-        // .tar — so a bare .gz still means a gzipped tar named code.tar.gz.
-        $sourceFile = 'code.tar.gz';
-        $sourceExtension = \strpos(\basename($source), '.');
-        if ($source !== '' && $source !== '0' && $sourceExtension !== false) {
-            $extension = \substr(\basename($source), $sourceExtension);
-            if ($extension !== '.gz') {
-                $sourceFile = 'code' . $extension;
-            }
-        }
+        // Known archive formats keep their identity inside the runtime;
+        // anything else keeps the legacy code.tar.gz name, which client
+        // commands reference regardless of the real format (zip sources,
+        // build artifacts stored as <uniqid>.gz).
+        $sourceFile = match (\pathinfo($source, PATHINFO_EXTENSION)) {
+            'tar' => 'code.tar',
+            'sqfs' => 'code.sqfs',
+            'erofs' => 'code.erofs',
+            default => 'code.tar.gz',
+        };
 
         // The source dir is mounted at /tmp inside the runtime, so this is
         // where the start helper (extract.sh) finds the archive.


### PR DESCRIPTION
## What

- Sets `OPEN_RUNTIMES_CODE_PATH=/tmp/<sourceFile>` on non-v2 runtime containers, derived from the same `$sourceFile` variable used to build the `/tmp` source mount.
- Known archive formats keep their identity in the mounted name — `.tar` → `code.tar`, `.sqfs` → `code.sqfs`, `.erofs` → `code.erofs` — instead of everything non-tar being mislabeled `code.tar.gz`. Anything else keeps the legacy `code.tar.gz` name, which client commands reference regardless of the real format (zip sources, build artifacts stored as `<uniqid>.gz`).

## Why

The open-runtimes start helper (`extract.sh`) extracts the archive named by `OPEN_RUNTIMES_CODE_PATH` directly into the function path. With the executor declaring it, orchestrators (e.g. Appwrite) can drop the `cp /tmp/code.* /mnt/code/` prefix from their runtime entrypoints instead of duplicating the executor's internal archive naming. Squashfs sources previously only extracted because `extract.sh` sniffs magic bytes; their mounted name is now truthful.

Counterpart: appwrite/appwrite#13440

🤖 Generated with [Claude Code](https://claude.com/claude-code)